### PR TITLE
FIX: Using bare variables is deprecated.

### DIFF
--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -6,7 +6,7 @@
 
 - name: OS Packages
   yum: "name={{ item }} state=present"
-  with_items: consul_centos_os_packages
+  with_items: "{{ consul_centos_os_packages }}"
   tags: installation
 
 - name: Download Consul

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -8,7 +8,7 @@
 
 - name: OS Packages
   yum: "name={{ item }} state=present"
-  with_items: consul_redhat_os_packages
+  with_items: "{{ consul_redhat_os_packages }}"
   tags: installation
 
 - name: Download Consul

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -6,7 +6,7 @@
 
 - name: OS Packages
   apt: "name={{ item }} state=present update_cache=yes"
-  with_items: consul_ubuntu_os_packages
+  with_items: "{{ consul_ubuntu_os_packages }}"
   tags: installation
 
 - name: Download Consul


### PR DESCRIPTION
This seems to be fixed in just debian. When using Ubuntu I still got:

> [DEPRECATION WARNING]: Using bare variables is deprecated. Update your 
> playbooks so that the environment value uses the full variable syntax 
> ('{{consul_ubuntu_os_packages}}').
> This feature will be removed in a future 
> release. Deprecation warnings can be disabled by setting

This PR fixes the use of with_items for all other distributions.
