### PR TITLE
FIX: No such file or directory /etc/init.d/functions

### DIFF
--- a/templates/consul_sysvinit.j2
+++ b/templates/consul_sysvinit.j2
@@ -5,7 +5,11 @@
 # processname: consul
 # pidfile: /var/run/consul/pidfile
 
+{% if ansible_distribution == "Ubuntu" %}
+. /lib/lsb/init-functions
+{% else %}
 . /etc/init.d/functions
+{% endif %}
 
 CONSUL=/usr/local/bin/consul
 CONFIG=/etc/consul.d/{{ consul_node_role }}


### PR DESCRIPTION
Quick fix taken from this SO: https://github.com/ansible/ansible-modules-core/issues/1563

Resolves Issue:

> Error when trying to enable consul: rc=1 Synchronizing state of consul.service with SysV init with /lib/systemd/systemd-sysv-install...
> Executing /lib/systemd/systemd-sysv-install enable consul
> insserv: warning: script 'consul' missing LSB tags and overrides\nupdate-rc.d: error: consul Default-Start contains no runlevels, aborting.
