### PR TITLE
Allowing re-running to add new nodes. More HA too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ inventory file (see below):
 | `consul_syslog_enable` | *true* | Log to syslog |
 | `consul_iface` | `eth1` | Consul network interface |
 | `consul_bind_address` | *127.0.0.1* | Bind address |
-| `consul_bootstrap_address` | `{{ hostvars[groups[consul_group_name][0]]['ansible_'+consul_iface]['ipv4']['address'] }}` | The server interface that additional server nodes will join to for bootstrapping |
 | `consul_dns_bind_address` | *127.0.0.1* | DNS API bind address |
 | `consul_http_bind_address` | *0.0.0.0* | HTTP API bind address |
 | `consul_https_bind_address` | *0.0.0.0* | HTTPS API bind address |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,6 @@ consul_dns_bind_address: "127.0.0.1"
 consul_http_bind_address: "0.0.0.0"
 consul_https_bind_address: "0.0.0.0"
 consul_rpc_bind_address: "0.0.0.0"
-consul_bootstrap_address: "{{ hostvars[groups[consul_group_name][0]]['ansible_'+consul_iface]['ipv4']['address'] }}"
 consul_node_name: "{{ inventory_hostname_short }}"
 consul_recursors: "{{ lookup('env','CONSUL_RECURSORS') | default('[]', true) }}"
 

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -1,23 +1,74 @@
 ---
 # File: tasks/acl.yml - ACL tasks for Consul
 
-- name: ACL Master Token
-  command: "echo {{ ansible_date_time.iso8601_micro | to_uuid }}"
-  run_once: True
-  register: consul_acl_master_token
+- block:
+  - name: Look for an existing ACL master token on a previously boostrapped server
+    shell: 'cat {{ consul_config_path }}/server/config_acl.json | grep "acl_master_token" | sed -E ''s/"acl_master_token": "(.+)",?/\1/'' | sed ''s/^ *//;s/ *$//'''
+    register: acl_master_token_read
+    run_once: true
+
+  - name: Save ACL master token key (from existing config)
+    set_fact: consul_acl_master_token={{ acl_master_token_read.stdout }}
+    when: acl_master_token_read.stdout != ''
+  when: consul_acl_master_token is not defined and bootstrap_marker.stat.exists
+
+- name: Writing ACL master token locally to share with other servers that are new
+  local_action: copy content={{ consul_acl_master_token }} dest=/tmp/acl_master_token
+  when: consul_acl_master_token is defined
+
+- name: Reading ACL master token for servers that are missing it
+  set_fact: consul_acl_master_token="{{ lookup('file', '/tmp/acl_master_token') }}"
+  when: consul_acl_master_token is not defined
+
+- name: Deleting ACL master token file
+  local_action: file path=/tmp/acl_master_token state=absent
+
+- block:
+  - name: Look for an existing ACL replication token on a previously boostrapped server
+    shell: 'cat {{ consul_config_path }}/server/config_acl.json | grep "acl_replication_token" | sed -E ''s/"acl_replication_token": "(.+)",?/\1/'' | sed ''s/^ *//;s/ *$//'''
+    register: consul_acl_replication_token_read
+    run_once: true
+
+  - name: Save ACL replication token key (from existing config)
+    set_fact: consul_acl_replication_token={{ consul_acl_replication_token_read.stdout }}
+  when: consul_acl_replication_token is not defined and bootstrap_marker.stat.exists
+
+- name: Writing ACL replication token locally to share with other servers that are new
+  local_action: copy content={{ consul_acl_replication_token }} dest=/tmp/acl_replication_token
+  when: consul_acl_replication_token is defined
+
+- name: Reading ACL replication token for servers that are missing it
+  set_fact: consul_acl_replication_token="{{ lookup('file', '/tmp/acl_replication_token') }}"
+  when: consul_acl_replication_token is not defined
+
+- name: Deleting ACL replication token file
+  local_action: file path=/tmp/acl_replication_token state=absent
+
+- block:
+  - name: Generate ACL master token
+    command: "echo {{ ansible_date_time.iso8601_micro | to_uuid }}"
+    register: consul_acl_master_token_keygen
+    run_once: true
+  - name: Save ACL master yoken
+    set_fact: consul_acl_master_token={{ consul_acl_master_token_keygen.stdout }}
+  when: consul_acl_master_token is not defined and not bootstrap_marker.stat.exists
 
 - name: Display ACL Master Token
-  debug: msg="{{ consul_acl_master_token['stdout'] }}"
+  debug: msg="{{ consul_acl_master_token }}"
   run_once: True
   when: consul_acl_master_token_display
 
-- name: ACL Replication Token
-  command: "echo {{ ansible_date_time.iso8601_micro | to_uuid }}"
-  run_once: True
-  register: consul_acl_replication_token
+- block:
+  - name: Generate ACL replication token
+    command: "echo {{ ansible_date_time.iso8601_micro | to_uuid }}"
+    register: consul_acl_replication_token_keygen
+    run_once: true
+  - name: Save ACL replication yoken
+    set_fact: consul_acl_replication_token={{ consul_acl_replication_token_keygen.stdout }}
+  when: (consul_acl_replication_token is not defined or consul_acl_replication_token == '') and not bootstrap_marker.stat.exists
 
 - name: Display ACL Replication Token
-  debug: msg="{{ consul_acl_replication_token['stdout'] }}"
+  debug: msg="{{ consul_acl_replication_token }}"
   run_once: True
   when: consul_acl_replication_token_display
 
@@ -27,6 +78,8 @@
   - bootstrap
   - client
   - server
+  notify:
+    - restart consul
 
 - name: ACL policy configuration
   template: src=config_acl_policy.hcl.j2 dest={{ consul_config_path }}/{{ item }}/config_acl_policy.hcl
@@ -34,3 +87,5 @@
   - bootstrap
   - client
   - server
+  notify:
+    - restart consul

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,7 +76,7 @@
   when: consul_raw_key is not defined
 
 - name: Deleting key file
-  local_action: file path=/tmp/consul_raw.key_directory state=absent
+  local_action: file path=/tmp/consul_raw.key state=absent
 
 - block:
     - name: Generate gossip encryption key

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
 
 - block:
     - name: Look for an existing encryption key on a previously boostrapped server
-      shell: 'cat {{ consul_config_path }}/bootstrap/config.json | grep "encrypt" | sed -E ''s/"encrypt": "(.+)",/\1/'' | sed ''s/^ *//;s/ *$//'''
+      shell: 'cat {{ consul_config_path }}/bootstrap/config.json | grep "encrypt" | sed -E ''s/"encrypt": "(.+)",?/\1/'' | sed ''s/^ *//;s/ *$//'''
       register: consul_key_read
       run_once: true
 
@@ -99,27 +99,33 @@
     - /etc/consul.d/bootstrap   
     - /etc/consul.d/client
     - /etc/consul.d/server
+
+- name: Bootstrap configuration
+  template: "src=config_bootstrap.json.j2 dest={{ consul_config_path }}/bootstrap/config.json"
+  notify:
+    - restart consul
+
+- name: Client configuration
+  template: "src=config_client.json.j2 dest={{ consul_config_path }}/client/config.json"
+  notify:
+    - restart consul
+
+- name: Server configuration
+  template: "src=config_server.json.j2 dest={{ consul_config_path }}/server/config.json"
+  notify:
+    - restart consul
+
+- include: ../tasks/acl.yml
+  when: consul_acl_enable
+
+- name: Atlas configuration
+  template: src=config_atlas.json.j2 dest={{ consul_config_path }}/{{ item }}/config_atlas.json
+  with_items:
+    - bootstrap
+    - server
+  when: consul_atlas_enable
+
 - block:
-
-  - name: Bootstrap configuration
-    template: "src=config_bootstrap.json.j2 dest={{ consul_config_path }}/bootstrap/config.json"
-
-  - name: Client configuration
-    template: "src=config_client.json.j2 dest={{ consul_config_path }}/client/config.json"
-
-  - name: Server configuration
-    template: "src=config_server.json.j2 dest={{ consul_config_path }}/server/config.json"
-
-  - include: ../tasks/acl.yml
-    when: consul_acl_enable
-
-  - name: Atlas configuration
-    template: src=config_atlas.json.j2 dest={{ consul_config_path }}/{{ item }}/config_atlas.json
-    with_items:
-      - bootstrap
-      - server
-    when: consul_atlas_enable
-
   - name: SYSV init script
     template: src=consul_sysvinit.j2 dest=/etc/init.d/consul owner=root group=root mode=755
     when: not ansible_service_mgr == "systemd" and not ansible_os_family == "Debian"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,6 +58,27 @@
   include: install.yml
 
 - block:
+    - name: Look for an existing encryption key on a previously boostrapped server
+      shell: 'cat {{ consul_config_path }}/bootstrap/config.json | grep "encrypt" | sed -E ''s/"encrypt": "(.+)",/\1/'' | sed ''s/^ *//;s/ *$//'''
+      register: consul_key_read
+      run_once: true
+
+    - name: Save encryption key (from existing config)
+      set_fact: consul_raw_key={{ consul_key_read.stdout }}
+  when: consul_raw_key is not defined and bootstrap_marker.stat.exists
+
+- name: Writing key locally to share with other servers that are new
+  local_action: copy content={{ consul_raw_key }} dest=/tmp/consul_raw.key
+  when: consul_raw_key is defined
+
+- name: Reading key for servers that are missing it
+  set_fact: consul_raw_key="{{ lookup('file', '/tmp/consul_raw.key') }}"
+  when: consul_raw_key is not defined
+
+- name: Deleting key file
+  local_action: file path=/tmp/consul_raw.key_directory state=absent
+
+- block:
     - name: Generate gossip encryption key
       shell: "PATH=/usr/local/bin:$PATH consul keygen"
       register: consul_keygen

--- a/templates/config_acl.json.j2
+++ b/templates/config_acl.json.j2
@@ -2,5 +2,6 @@
   "acl_datacenter": "{{ consul_acl_datacenter }}",
   "acl_default_policy": "{{ consul_acl_default_policy }}",
   "acl_down_policy": "{{ consul_acl_down_policy }}",
-  "acl_master_token": "{{ consul_acl_master_token['stdout'] }}"
+  "acl_master_token": "{{ consul_acl_master_token }}",
+  "acl_replication_token": "{{ consul_acl_replication_token }}"
 }

--- a/templates/config_client.json.j2
+++ b/templates/config_client.json.j2
@@ -1,4 +1,5 @@
 {% set comma = joiner(", ") %}
+{% set comma_nodes = joiner(", ") %}
 
 {
   "bind_addr": "{{ consul_bind_address }}",
@@ -21,5 +22,12 @@
   "encrypt": "{{ consul_raw_key }}",
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
-  "start_join": [ "{{ consul_bootstrap_address }}" ]
+  "start_join": [
+      {% set interface = 'ansible_' ~ consul_iface %}
+         {% for host in groups[consul_group_name] %}
+         {% if host != inventory_hostname and (hostvars[host]['consul_node_role'] == 'server' or hostvars[host]['consul_node_role'] == 'bootstrap') %}
+         {{ comma_nodes() }}"{{ hostvars[host][interface]['ipv4']['address'] }}"
+         {% endif %}
+         {% endfor %}
+     ]
 }

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -1,4 +1,5 @@
 {% set comma = joiner(", ") %}
+{% set comma_nodes = joiner(", ") %}
 
 {
   "bind_addr": "{{ consul_bind_address }}",
@@ -21,6 +22,13 @@
   "encrypt": "{{ consul_raw_key }}",
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
-  "start_join": [ "{{ consul_bootstrap_address }}" ],
+  "start_join": [
+    {% set interface = 'ansible_' ~ consul_iface %}
+    {% for host in groups[consul_group_name] %}
+    {% if host != inventory_hostname and (hostvars[host]['consul_node_role'] == 'server' or hostvars[host]['consul_node_role'] == 'bootstrap') %}
+    {{ comma_nodes() }}"{{ hostvars[host][interface]['ipv4']['address'] }}"
+    {% endif %}
+    {% endfor %}
+   ],
   "ui": true
 }


### PR DESCRIPTION
Firstly, great role, it's really helped me, but it wasn't perfect in just a couple of ways, so I've made some changes to try to give back to the community. This PR does two things:

1. Previously if you re-ran the role with new nodes added, the new nodes would not be set up properly. They would not know the encryption key for a start, so could never connect.
2. The var `consul_bootstrap_address` was a bit too much of an assumption (your first node might not be the bootstrap node, but this assumed it was). Additionally, you should really be including the entire array of `server` nodes in the `start_join` config value, not just the first one. What if that node went down and then you restarted consul on another node? I've changed it to include all `server` and `bootstrap` nodes (apart from itself). Remember, the `bootstrap` node will become a `server` node shortly.
3. It does a similar with for the ACL token as it now does for encryption keys. Also the ACL replication token was never being set before, but now is.

Again, thanks for such a great role and I hope these changes help others too.