### PR TITLE
Updating default consul_bind_address to sane value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ consul_domain: "consul"
 consul_log_level: "INFO"
 consul_syslog_enable: true
 consul_iface: "eth1"
-consul_bind_address: "{{ hostvars[inventory_hostname]['ansible_'+ consul_iface ]['ipv4'][0].address }}"
+consul_bind_address: "{{ hostvars[inventory_hostname]['ansible_'+ consul_iface ]['ipv4']['address'] }}"
 consul_dns_bind_address: "127.0.0.1"
 consul_http_bind_address: "0.0.0.0"
 consul_https_bind_address: "0.0.0.0"


### PR DESCRIPTION
This appears to have been broken in 47c9589a5cb16f8a71c504031ba12fb93e135ca3

ipv4 is an object, not an array.
defaults back to address property of ipv4 from consul_iface