### PR TITLE
Feature support arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ inventory file (see below):
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `consul_architecture_map`|  | dict translating ansible_architecture to hashi architecture naming convention |
-| `consul_architecture`| `amd64`,`arm`,`arm64` | determined by "{{ consul_architecture_map[ansible_architecture] }}" |
+| `consul_architecture`| `amd64`,`arm`,`arm64` | determined by `{{ consul_architecture_map[ansible_architecture] }}` |
 | `consul_version` | *0.7.5* | Version to install |
 | `consul_zip_url` | `https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_linux_{{ consul_architecture }}.zip` | Download URL |
 | `consul_checksum_file_url` | `https://releases.hashicorp.com/consul/{{ consul_version }}/{{ consul_version }}_SHA256SUMS` | URL to package SHA256 summaries |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ inventory file (see below):
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `consul_architecture_map`| | | dict translating ansible_architecture to hashi architecture naming convention|
+| `consul_architecture_map`|  | dict translating ansible_architecture to hashi architecture naming convention |
 | `consul_architecture`| `amd64`,`arm`,`arm64` | determined by "{{ consul_architecture_map[ansible_architecture] }}" |
 | `consul_version` | *0.7.5* | Version to install |
 | `consul_zip_url` | `https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_linux_{{ consul_architecture }}.zip` | Download URL |

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ inventory file (see below):
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
+| `consul_architecture_map`| | | dict translating ansible_architecture to hashi architecture naming convention|
+| `consul_architecture`| `amd64`,`arm`,`arm64` | determined by "{{ consul_architecture_map[ansible_architecture] }}" |
 | `consul_version` | *0.7.5* | Version to install |
-| `consul_zip_url` | `https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_linux_amd64.zip` | Download URL |
+| `consul_zip_url` | `https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_linux_{{ consul_architecture }}.zip` | Download URL |
 | `consul_checksum_file_url` | `https://releases.hashicorp.com/consul/{{ consul_version }}/{{ consul_version }}_SHA256SUMS` | URL to package SHA256 summaries |
 | `consul_bin_path` | `/usr/local/bin` | Binary installation path |
 | `consul_config_path` | `/etc/consul.d` | Configuration file path |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,16 @@
 ---
 # File: defaults/main.yml - Default variables for Consul
 
+## match cpu arch to hashi naming convention
+consul_architecture_map:
+  x86_64: amd64
+  armv7l: arm
+  aarch64: arm64
+consul_architecture: "{{ consul_architecture_map[ansible_architecture] }}"
+
 ## Core
 consul_version: "{{ lookup('env','CONSUL_VERSION') | default('0.7.5', true) }}"
-consul_zip_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_linux_amd64.zip"
+consul_zip_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_linux_{{consul_architecture}}.zip"
 consul_checksum_file_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version}}_SHA256SUMS"
 consul_bin_path: "/usr/local/bin"
 consul_config_path: "/etc/consul.d"
@@ -54,4 +61,4 @@ consul_iptables_enable: "{{ lookup('env','CONSUL_IPTABLES_ENABLE') | default(fal
 ## Distribution
 
 ### Consul
-consul_pkg: "consul_{{ consul_version }}_linux_amd64.zip"
+consul_pkg: "consul_{{ consul_version }}_linux_{{consul_architecture}}.zip"


### PR DESCRIPTION
I modified defaults to use a lookup table to translate `ansible_architecture` to the appropriate hashi naming convention so that the role may be used with arm.   The table can easily be added for other `ansible_architecture` returned facts

I've tested successfully tested on Arm7 (OrangePI Plus 2e w/ AllWinner H3) Runnning Armbian Ubuntu Xenial.