### PR TITLE
Add consul_ports to specify rpc/http/https/dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ inventory file (see below):
 | `consul_http_bind_address` | *0.0.0.0* | HTTP API bind address |
 | `consul_https_bind_address` | *0.0.0.0* | HTTPS API bind address |
 | `consul_rpc_bind_address` | *0.0.0.0* | RPC bind address |
+| `consul_ports` | `rpc`: `8400`<br/>`http`: `8500`<br/>`https`: `-1`<br/>`dns`: `8600` | Port Mappings |
 | `consul_node_name` | `{{ inventory_hostname_short }}` | Node name (should not include dots) |
 | `consul_recursors` | Empty list | List of upstream DNS servers — see [recursors](https://www.consul.io/docs/agent/options.html#recursors) | 
 | `consul_bind_address` | dynamic from hosts inventory | The interface address to bind to

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,11 @@ consul_https_bind_address: "0.0.0.0"
 consul_rpc_bind_address: "0.0.0.0"
 consul_node_name: "{{ inventory_hostname_short }}"
 consul_recursors: "{{ lookup('env','CONSUL_RECURSORS') | default('[]', true) }}"
+consul_ports:
+  rpc: 8400
+  http: 8500
+  https: -1
+  dns: 8600
 
 ## ACL
 consul_acl_enable: "{{ lookup('env','CONSUL_ACL_ENABLE') | default(false, true) }}"

--- a/templates/config_bootstrap.json.j2
+++ b/templates/config_bootstrap.json.j2
@@ -13,6 +13,9 @@
                      {{ comma() }}"{{ recursor }}"
                  {%- endfor %} ],
   {% endif %}
+  {% if consul_ports %}
+  "ports": {{ consul_ports | to_nice_json }},
+  {% endif %}
   "bootstrap": true,
   "server": true,
   "node_name": "{{ consul_node_name }}",

--- a/templates/config_client.json.j2
+++ b/templates/config_client.json.j2
@@ -14,6 +14,9 @@
                      {{ comma() }}"{{ recursor }}"
                  {%- endfor %} ],
   {% endif %}
+  {% if consul_ports %}
+  "ports": {{ consul_ports | to_nice_json }},
+  {% endif %}
   "bootstrap": false,
   "server": false,
   "node_name": "{{ consul_node_name }}",

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -9,6 +9,9 @@
     "https": "{{ consul_https_bind_address }}",
     "rpc": "{{ consul_rpc_bind_address }}"
   },
+  {% if consul_ports %}
+  "ports": {{ consul_ports | to_nice_json }},
+  {% endif %}
   {%- if consul_recursors|length > 0 -%}
   "recursors": [ {% for recursor in consul_recursors -%}
                      {{ comma() }}"{{ recursor }}"


### PR DESCRIPTION
Adds `consul_ports` configuration to allow users to specify the ports to bind to.  

default:
```yaml
consul_ports:
  rpc: 8400
  http: 8500
  https: -1
  dns: 8600
```

To use HTTPS intead of HTTP a user can specify:
```yaml
consul_ports:
  rpc: 8400
  http: -1
  https: 8500
  dns: 8600
```