### PR TITLE
Add consul_config_custom for role users to specify new or overwrite existing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ inventory file (see below):
 | `consul_verify_outgoing` | *true* | Verify outgoing connections, can be overridden with `CONSUL_VERIFY_OUTGOING` environment variable |
 | `consul_verify_server_hostname` | *false* | Verify server hostname, can be overridden with `CONSUL_VERIFY_SERVER_HOSTNAME` environment variable |
 
+### Custom Configuration Sections
+
+As Consul loads the configuration from files and directories in lexical order, typically merging on top of previously parsed configuration files, you may set
+custom configurations via `consul_config_custom`, which will be expanded into a file named `XXX_config_custom.json` within your `consul_config_path`.
+
+
+An example usage may be for enabling `telemetry`
+```yaml
+  vars:
+    consul_config_custom:
+      telemetry:
+        dogstatsd_addr: "localhost:8125"
+        dogstatsd_tags:
+          - "security"
+          - "compliance"
+        disable_hostname: true
+```
+
 ### Host Inventory Variable
 
 This role also uses a host inventory variable to define the server's role

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -164,6 +164,16 @@
   notify:
     - restart consul
 
+- name: Extra configurations
+  template:
+    src: consul_XXX_config_custom.json.j2
+    dest: "{{ consul_config_path }}/{{ item }}/XXX_config_custom.json"
+  with_items:
+    - [ "bootstrap", "client", "server" ]
+  when: consul_config_custom is defined and item == consul_node_role
+  notify:
+    - restart consul
+
 - include: ../tasks/acl.yml
   when: consul_acl_enable
 

--- a/templates/consul_XXX_config_custom.json.j2
+++ b/templates/consul_XXX_config_custom.json.j2
@@ -1,0 +1,6 @@
+{# consul_config_custom variables are free-style, passed through a hash -#}
+{% if consul_config_custom -%}
+{{ consul_config_custom | to_nice_json }}
+{% else %}
+{}
+{% endif %}


### PR DESCRIPTION
Enables the ability for the user to extend the configuration to whatever they may need
without it being explicitly defined within the role