### PR TITLE
Update installation tags to allow for targeted runs

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,6 +15,7 @@
     path: "{{ role_path }}/files/consul_{{ consul_version }}_SHA256SUMS"
   run_once: true
   register: consul_checksum
+  tags: installation
 
 - name: Get Consul package checksum file
   become: no
@@ -41,6 +42,7 @@
     path: "{{ role_path }}/files/{{ consul_pkg }}"
   run_once: true
   register: consul_package
+  tags: installation
 
 - name: Download Consul
   become: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,7 @@
     path: /etc/consul/.consul_bootstrapped
   register: bootstrap_marker
   ignore_errors: true
+  tags: always
 
 - name: Add Consul user
   user:
@@ -62,6 +63,7 @@
 
 - name: OS-specific variables
   include_vars: "{{ ansible_os_family }}.yml"
+  tags: always
 
 - name: Install OS packages
   include: install.yml


### PR DESCRIPTION
Some facts and vars are required for installation that were not always available.