### PR TITLE
ensure gossip encryption key is generated once

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -133,6 +133,7 @@
     - name: Generate gossip encryption key
       shell: "PATH={{ consul_bin_path }}:$PATH consul keygen"
       register: consul_keygen
+      run_once: true
 
     - name: Save encryption key
       set_fact: consul_raw_key={{ consul_keygen.stdout }}


### PR DESCRIPTION
My first PR was a bit too aggressive in eliminating the _run_once_ clauses.

This one is actually needed in order to generate the encryption key only one time. Without the _run_once_ every host will get different key and at the end Consul agents won't be able to talk to each other.

This time tested the playbook on both fresh new cluster and on existing one, all runs completed w/o errors.

