### PR TITLE
Cleanup and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ inventory file (see below):
 
 - Consul network interface
   - Override with `CONSUL_IFACE` environment variable
-- Default value: determined from host inventory
+- Default value: `{{ ansible_default_ipv4.interface }}`
 
 ### `consul_bind_address`
 
@@ -301,6 +301,25 @@ inventory file (see below):
 - Whether to download the files for installation directly on the remote hosts
 - Default value: *false*
 
+### `consul_node_role`
+
+- Consul server role, one of: *bootstrap*, *server*, or *client*
+- Default value: *client*
+
+One server should be designated as the bootstrap
+server that uses the `bootstrap_expect` configuration directive, and the other
+servers will connect to this server. You can also specify *client* as the
+role, and Consul will be configured as a client agent instead of a server.
+
+Here is an example of how the hosts inventory could be defined for a simple
+cluster of 3 servers:
+
+```
+consul1.local consul_node_role=bootstrap
+consul2.local consul_node_role=server
+consul3.local consul_node_role=server
+```
+
 #### Custom Configuration Section
 
 As Consul loads the configuration from files and directories in lexical order,
@@ -319,33 +338,6 @@ An example usage for enabling `telemetry`:
           - "security"
           - "compliance"
         disable_hostname: true
-```
-
-## Host Inventory Variables
-
-This role also uses a host inventory variable to define the server's role
-when forming a cluster. One server should be designated as the bootstrap
-server that uses the `bootstrap_expect` configuration directive, and the other
-servers will connect to this server. You can also specify *client* as the
-role, and Consul will be configured as a client agent instead of a server.
-
-### `consul_iface`
-
-- Consul server role, one of: *bootstrap*, *server*, or *client*
-- Default value: NONE
-
-### `consul_node_role`
-
-- Consul server role, one of: *bootstrap*, *server*, or *client*
-- Default value: NONE
-
-Here is an example of how the hosts inventory could be defined for a simple
-cluster of 3 servers:
-
-```
-consul1.local consul_node_role=bootstrap
-consul2.local consul_node_role=server
-consul3.local consul_node_role=server
 ```
 
 ## OS Distribution Variables

--- a/README.md
+++ b/README.md
@@ -100,6 +100,25 @@ inventory file (see below):
   - Override with `CONSUL_GROUP_NAME` environment variable
 - Default value: *cluster_nodes*
 
+### `consul_servers`
+
+Although overwritable, it should not be necessary to manually alter this list.
+
+- List of server nodes
+- Default value: List of all nodes in `consul_group_name` with
+  `consul_node_role` set to *server* or *bootstrap*
+
+### `consul_gather_server_facts`
+
+This feature makes it possible to gather the `consul_bind_address` from servers
+that are currently not targeted by the playbook.
+
+To make this possible the `delegate_facts` option is used. This option is broken
+in many Ansible versions, so this feature might not always work.
+
+- Gather facts from servers that are not currently targeted
+- Default value: 'no'
+
 ### `consul_datacenter`
 
 - Datacenter label

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,7 +68,7 @@ consul_servers: "\
   {% set _consul_servers=[] %}\
   {% for host in groups[consul_group_name] %}\
   {% if (hostvars[host]['consul_node_role'] == 'server' or hostvars[host]['consul_node_role'] == 'bootstrap') %}\
-      {% do _consul_servers.append(host) %}\
+      {% if _consul_servers.append(host) %}{% endif %}\
     {% endif %}\
   {% endfor %}\
   {{ _consul_servers }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ consul_log_level: "{{ lookup('env','CONSUL_LOG_LEVEL') | default('INFO', true) }
 consul_syslog_enable: "{{ lookup('env','CONSUL_SYSLOG_ENABLE') | default(true, true) }}"
 consul_iface: "{{ lookup('env','CONSUL_IFACE') | default(ansible_default_ipv4.interface, true) }}"
 consul_node_name: "{{ inventory_hostname_short }}"
+consul_node_role: "{{ lookup('env','CONSUL_NODE_ROLE') | default('client', true) }}"
 consul_recursors: "{{ lookup('env','CONSUL_RECURSORS') | default('[]', true) }}"
 
 ### Addresses

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,9 +27,9 @@ consul_data_path: "/var/consul"
 consul_log_path: "/var/log/consul"
 
 ### System user and group
-consul_manage_user: 'yes'
+consul_manage_user: yes
 consul_user: "consul"
-#consul_manage_group: 'no'
+#consul_manage_group: no
 consul_group: "bin"
 
 ### Consul settings
@@ -53,7 +53,7 @@ consul_dns_bind_address: "127.0.0.1"
 consul_http_bind_address: "0.0.0.0"
 consul_https_bind_address: "0.0.0.0"
 consul_rpc_bind_address: "0.0.0.0"
-consul_vault_address: "{{ vault_address | default('0.0.0.0') }}"
+consul_vault_address: "{{ vault_address | default('0.0.0.0', true) }}"
 
 ### Ports
 consul_ports:
@@ -72,7 +72,7 @@ consul_servers: "\
     {% endif %}\
   {% endfor %}\
   {{ _consul_servers }}"
-consul_gather_server_facts: 'no'
+consul_gather_server_facts: no
 
 ## ACL
 consul_acl_enable: "{{ lookup('env','CONSUL_ACL_ENABLE') | default(false, true) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,9 @@ consul_data_path: "/var/consul"
 consul_log_path: "/var/log/consul"
 
 ### System user and group
+consul_manage_user: 'yes'
 consul_user: "consul"
+#consul_manage_group: 'no'
 consul_group: "bin"
 
 ### Consul settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # File: main.yml - Default variables for Consul
 
 ## Core
+
+### Package
 consul_version: "{{ lookup('env','CONSUL_VERSION') | default('0.8.0', true) }}"
 consul_architecture_map:
   # this first entry seems... redundant (but it's required for reasons)
@@ -11,33 +13,62 @@ consul_architecture_map:
   aarch64: arm64
 consul_architecture: "{{ consul_architecture_map[ansible_architecture] }}"
 consul_os: "{{ ansible_system|lower }}"
+consul_pkg: "consul_{{ consul_version }}_{{ consul_os }}_{{ consul_architecture }}.zip"
 consul_zip_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_{{ consul_os }}_{{ consul_architecture }}.zip"
 consul_checksum_file_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version}}_SHA256SUMS"
+
+### Install Method
+consul_install_remotely: false
+
+### Path's
 consul_bin_path: "/usr/local/bin"
 consul_config_path: "/etc/consul.d"
 consul_data_path: "/var/consul"
 consul_log_path: "/var/log/consul"
+
+### System user and group
 consul_user: "consul"
 consul_group: "bin"
-consul_group_name: "{{ lookup('env','CONSUL_GROUP_NAME') | default('cluster_nodes', true) }}"
+
+### Consul settings
 consul_datacenter: "{{ lookup('env','CONSUL_DATACENTER') | default('dc1', true) }}"
 consul_domain: "{{ lookup('env','CONSUL_DOMAIN') | default('consul', true) }}"
 consul_log_level: "{{ lookup('env','CONSUL_LOG_LEVEL') | default('INFO', true) }}"
 consul_syslog_enable: "{{ lookup('env','CONSUL_SYSLOG_ENABLE') | default(true, true) }}"
-consul_iface: "{{ lookup('env','CONSUL_IFACE') | default(hostvars.consul_iface, true) }}"
-vault_address: "0.0.0.0"
-consul_bind_address: "{{ lookup('env','CONSUL_BIND_ADDRESS') | default(hostvars[inventory_hostname]['ansible_'+ consul_iface ]['ipv4']['address'], true) }}"
+consul_iface: "{{ lookup('env','CONSUL_IFACE') | default(ansible_default_ipv4.interface, true) }}"
+consul_node_name: "{{ inventory_hostname_short }}"
+consul_recursors: "{{ lookup('env','CONSUL_RECURSORS') | default('[]', true) }}"
+
+### Addresses
+consul_bind_address: "\
+  {% if ansible_system == 'FreeBSD' %}\
+    {{ lookup('env','CONSUL_BIND_ADDRESS') | default(hostvars[inventory_hostname]['ansible_'+ consul_iface ]['ipv4'][0]['address'], true) }}\
+  {% else %}\
+    {{ lookup('env','CONSUL_BIND_ADDRESS') | default(hostvars[inventory_hostname]['ansible_'+ consul_iface ]['ipv4']['address'], true) }}\
+  {% endif %}"
 consul_dns_bind_address: "127.0.0.1"
 consul_http_bind_address: "0.0.0.0"
 consul_https_bind_address: "0.0.0.0"
 consul_rpc_bind_address: "0.0.0.0"
-consul_node_name: "{{ inventory_hostname_short }}"
-consul_recursors: "{{ lookup('env','CONSUL_RECURSORS') | default('[]', true) }}"
+vault_address: "0.0.0.0"
+
+### Ports
 consul_ports:
   rpc: 8400
   http: 8500
   https: -1
   dns: 8600
+
+### Servers
+consul_group_name: "{{ lookup('env','CONSUL_GROUP_NAME') | default('cluster_nodes', true) }}"
+consul_servers: "\
+  {% set _consul_servers=[] %}\
+  {% for host in groups[consul_group_name] %}\
+  {% if (hostvars[host]['consul_node_role'] == 'server' or hostvars[host]['consul_node_role'] == 'bootstrap') %}\
+      {% do _consul_servers.append(host) %}\
+    {% endif %}\
+  {% endfor %}\
+  {{ _consul_servers }}"
 
 ## ACL
 consul_acl_enable: "{{ lookup('env','CONSUL_ACL_ENABLE') | default(false, true) }}"
@@ -66,10 +97,3 @@ consul_dnsmasq_enable: "{{ lookup('env','CONSUL_DNSMASQ_ENABLE') | default(false
 consul_iptables_enable: "{{ lookup('env','CONSUL_IPTABLES_ENABLE') | default(false, true) }}"
 
 ## Distribution
-
-### Consul
-
-consul_pkg: "consul_{{ consul_version }}_{{ consul_os }}_{{ consul_architecture }}.zip"
-
-### Install Method
-consul_install_remotely: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,6 +70,7 @@ consul_servers: "\
     {% endif %}\
   {% endfor %}\
   {{ _consul_servers }}"
+consul_gather_server_facts: 'no'
 
 ## ACL
 consul_acl_enable: "{{ lookup('env','CONSUL_ACL_ENABLE') | default(false, true) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,7 +53,7 @@ consul_dns_bind_address: "127.0.0.1"
 consul_http_bind_address: "0.0.0.0"
 consul_https_bind_address: "0.0.0.0"
 consul_rpc_bind_address: "0.0.0.0"
-vault_address: "0.0.0.0"
+consul_vault_address: "{{ vault_address | default('0.0.0.0') }}"
 
 ### Ports
 consul_ports:

--- a/tasks/dirs.yml
+++ b/tasks/dirs.yml
@@ -1,0 +1,26 @@
+---
+# File: dirs.yml - Directory settings
+
+- name: Create directories
+  file:
+    dest: "{{ item }}"
+    state: directory
+    owner: "{{ consul_user }}"
+    group: "{{ consul_group}}"
+  with_items:
+    - /etc/consul
+    - /opt/consul
+    - /var/consul
+    - /var/log/consul
+    - /var/run/consul
+    - /etc/consul.d
+    - /etc/consul.d/bootstrap
+    - /etc/consul.d/client
+    - /etc/consul.d/server
+
+- name: Ensure bin path
+  file:
+    path: "{{ consul_bin_path }}"
+    state: directory
+    owner: root
+    mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,29 +4,20 @@
 - name: Include checks/asserts
   include: asserts.yml
 
-- name: OS-specific variables
+- name: Include OS-specific variables
   include_vars: "{{ ansible_os_family }}.yml"
   tags: always
 
-- name: debug
-  debug:
-    var: consul_servers
-
-- name: debug
-  debug:
-    var: play_hosts
-
-# Gathers facts from servers not currently targeted
-- name: Gather facts from servers
+# Gathers facts (bind address) from servers not currently targeted.
+# 'delegate_facts' is currently rather buggy in Ansible so this might not
+# always work. Hence 'consul_gather_server_facts' defaults to 'no'.
+- name: Gather facts from other servers
   setup:
   delegate_to: "{{ item }}"
   delegate_facts: True
   with_items: "{{ consul_servers|difference(play_hosts) }}"
-  #ignore_errors: yes
-
-- name: debug
-  debug:
-    var: hostvars
+  ignore_errors: yes
+  when: consul_gather_server_facts|string in 'True,true,Yes,yes,Y,y,1'
 
 - name: Check bootstrapped state
   stat:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,26 @@
   include_vars: "{{ ansible_os_family }}.yml"
   tags: always
 
+- name: debug
+  debug:
+    var: consul_servers
+
+- name: debug
+  debug:
+    var: play_hosts
+
+# Gathers facts from servers not currently targeted
+- name: Gather facts from servers
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: True
+  with_items: "{{ consul_servers|difference(play_hosts) }}"
+  #ignore_errors: yes
+
+- name: debug
+  debug:
+    var: hostvars
+
 - name: Check bootstrapped state
   stat:
     path: /etc/consul/.consul_bootstrapped
@@ -124,16 +144,6 @@
   become: no
   run_once: true
   delegate_to: localhost
-
-- name: Select Consul network interface for Linux
-  set_fact:
-    consul_bind_address: "{{ hostvars[inventory_hostname]['ansible_'+ consul_iface ]['ipv4']['address'] }}"
-  when: ansible_os_family == "Linux"
-
-- name: Select Consul network interface for BSD and SmartOS
-  set_fact:
-    consul_bind_address: "{{ hostvars[inventory_hostname]['ansible_'+ consul_iface ]['ipv4'][0]['address'] }}"
-  when: ansible_os_family == "FreeBSD" or ansible_os_family == "SmartOS"
 
 - name: Bootstrap configuration
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,12 +26,8 @@
   ignore_errors: true
   tags: always
 
-- name: Add Consul user
-  user:
-    name: "{{ consul_user }}"
-    comment: "Consul user"
-    group: "{{ consul_group }}"
-    system: yes
+- name: Include user/group settings
+  include: user_group.yml
 
 - name: Create directories
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   delegate_facts: True
   with_items: "{{ consul_servers|difference(play_hosts) }}"
   ignore_errors: yes
-  when: consul_gather_server_facts|string in 'True,true,Yes,yes,Y,y,1'
+  when: consul_gather_server_facts|bool
 
 - name: Expose consul_bind_address as fact
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,10 @@
   ignore_errors: yes
   when: consul_gather_server_facts|string in 'True,true,Yes,yes,Y,y,1'
 
+- name: Expose consul_bind_address as fact
+  set_fact:
+    consul_bind_address: "{{ consul_bind_address }}"
+
 - name: Check bootstrapped state
   stat:
     path: /etc/consul/.consul_bootstrapped

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,29 +29,8 @@
 - name: Include user/group settings
   include: user_group.yml
 
-- name: Create directories
-  file:
-    dest: "{{ item }}"
-    state: directory
-    owner: "{{ consul_user }}"
-    group: "{{ consul_group}}"
-  with_items:
-    - /etc/consul
-    - /opt/consul
-    - /var/consul
-    - /var/log/consul
-    - /var/run/consul
-    - /etc/consul.d
-    - /etc/consul.d/bootstrap
-    - /etc/consul.d/client
-    - /etc/consul.d/server
-
-- name: Ensure bin path
-  file:
-    path: "{{ consul_bin_path }}"
-    state: directory
-    owner: root
-    mode: 0755
+- name: Include dir settings
+  include: dirs.yml
 
 - name: Install OS packages and consul - locally
   include: install.yml

--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -11,5 +11,5 @@
     comment: "Consul user"
     group: "{{ consul_group }}"
     system: yes
-  when: consul_manage_user|string in 'True,true,Yes,yes,Y,y,1'
+  when: consul_manage_user|bool
 

--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -1,0 +1,14 @@
+---
+
+# Add group
+# @TODO
+
+# Add user
+- name: Add Consul user
+  user:
+    name: "{{ consul_user }}"
+    comment: "Consul user"
+    group: "{{ consul_group }}"
+    system: yes
+  when: consul_manage_user|string in 'True,true,Yes,yes,Y,y,1'
+

--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -1,4 +1,5 @@
 ---
+# File: user_group.yml - User and group settings
 
 # Add group
 # @TODO

--- a/templates/config_bootstrap.json.j2
+++ b/templates/config_bootstrap.json.j2
@@ -6,17 +6,17 @@
     "https": "{{ consul_https_bind_address }}",
     "rpc": "{{ consul_rpc_bind_address }}"
   },
-  {% if consul_ports %}
-  "ports": {{ consul_ports | to_nice_json }},
-  {% endif %}
-  {%- if consul_recursors|length > 0 -%}
-  "recursors": [
-    {% set comma = joiner(", ") %}
-    {% for recursor in consul_recursors -%}
-      {{ comma() }}"{{ recursor }}"
-    {%- endfor %}
+  {% if consul_ports -%}
+    "ports": {{ consul_ports | to_nice_json }},
+  {% endif -%}
+  {% if consul_recursors|length > 0 -%}
+    "recursors": [
+      {%- set comma = joiner(", ") -%}
+      {% for recursor in consul_recursors -%}
+        {{ comma() }}"{{ recursor }}"
+      {%- endfor -%}
     ],
-  {% endif %}
+  {% endif -%}
   "bootstrap": true,
   "server": true,
   "node_name": "{{ consul_node_name }}",

--- a/templates/config_bootstrap.json.j2
+++ b/templates/config_bootstrap.json.j2
@@ -1,5 +1,3 @@
-{% set comma = joiner(", ") %}
-
 {
   "bind_addr": "{{ consul_bind_address }}",
   "addresses": {
@@ -8,13 +6,16 @@
     "https": "{{ consul_https_bind_address }}",
     "rpc": "{{ consul_rpc_bind_address }}"
   },
-  {%- if consul_recursors|length > 0 -%}
-  "recursors": [ {% for recursor in consul_recursors -%}
-                     {{ comma() }}"{{ recursor }}"
-                 {%- endfor %} ],
-  {% endif %}
   {% if consul_ports %}
   "ports": {{ consul_ports | to_nice_json }},
+  {% endif %}
+  {%- if consul_recursors|length > 0 -%}
+  "recursors": [
+    {% set comma = joiner(", ") %}
+    {% for recursor in consul_recursors -%}
+      {{ comma() }}"{{ recursor }}"
+    {%- endfor %}
+    ],
   {% endif %}
   "bootstrap": true,
   "server": true,

--- a/templates/config_bootstrap.json.j2
+++ b/templates/config_bootstrap.json.j2
@@ -10,12 +10,10 @@
     "ports": {{ consul_ports | to_nice_json }},
   {% endif -%}
   {% if consul_recursors|length > 0 -%}
-    "recursors": [
-      {%- set comma = joiner(", ") -%}
+    "recursors": [ {% set comma = joiner(", ") -%}
       {% for recursor in consul_recursors -%}
         {{ comma() }}"{{ recursor }}"
-      {%- endfor -%}
-    ],
+      {%- endfor %} ],
   {% endif -%}
   "bootstrap": true,
   "server": true,

--- a/templates/config_client.json.j2
+++ b/templates/config_client.json.j2
@@ -6,17 +6,17 @@
     "https": "{{ consul_https_bind_address }}",
     "rpc": "{{ consul_rpc_bind_address }}"
   },
-  {% if consul_ports %}
-  "ports": {{ consul_ports | to_nice_json }},
-  {% endif %}
-  {%- if consul_recursors|length > 0 -%}
-  "recursors": [
-    {% set comma = joiner(", ") %}
-    {% for recursor in consul_recursors -%}
-      {{ comma() }}"{{ recursor }}"
-    {%- endfor %}
+  {% if consul_ports -%}
+    "ports": {{ consul_ports | to_nice_json }},
+  {% endif -%}
+  {% if consul_recursors|length > 0 -%}
+    "recursors": [
+      {%- set comma = joiner(", ") -%}
+      {% for recursor in consul_recursors -%}
+        {{ comma() }}"{{ recursor }}"
+      {%- endfor -%}
     ],
-  {% endif %}
+  {% endif -%}
   "bootstrap": false,
   "server": false,
   "node_name": "{{ consul_node_name }}",
@@ -26,9 +26,9 @@
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
   "start_join": [
-    {% set comma_nodes = joiner(", ") %}
-    {% for server in consul_servers %}
+    {%- set comma_nodes = joiner(", ") -%}
+    {% for server in consul_servers -%}
       {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] }}"
-    {% endfor %}
-    ]
+    {%- endfor -%}
+  ]
 }

--- a/templates/config_client.json.j2
+++ b/templates/config_client.json.j2
@@ -1,6 +1,3 @@
-{% set comma = joiner(", ") %}
-{% set comma_nodes = joiner(", ") %}
-
 {
   "bind_addr": "{{ consul_bind_address }}",
   "addresses": {
@@ -10,9 +7,12 @@
     "rpc": "{{ consul_rpc_bind_address }}"
   },
   {%- if consul_recursors|length > 0 -%}
-  "recursors": [ {% for recursor in consul_recursors -%}
-                     {{ comma() }}"{{ recursor }}"
-                 {%- endfor %} ],
+  "recursors": [
+    {% set comma = joiner(", ") %}
+    {% for recursor in consul_recursors -%}
+      {{ comma() }}"{{ recursor }}"
+    {%- endfor %}
+    ],
   {% endif %}
   {% if consul_ports %}
   "ports": {{ consul_ports | to_nice_json }},
@@ -26,17 +26,9 @@
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
   "start_join": [
-      {% set interface = 'ansible_' ~ consul_iface %}
-      {% for host in groups[consul_group_name] %}
-      {% if ansible_system == 'FreeBSD' %}
-        {% if host != inventory_hostname and (hostvars[host]['consul_node_role'] == 'server' or hostvars[host]['consul_node_role'] == 'bootstrap') %}
-        {{ comma_nodes() }}"{{ hostvars[host][interface]['ipv4'][0]['address'] }}"
-        {% endif %}
-      {% else %}
-        {% if host != inventory_hostname and (hostvars[host]['consul_node_role'] == 'server' or hostvars[host]['consul_node_role'] == 'bootstrap') %}
-        {{ comma_nodes() }}"{{ hostvars[host][interface]['ipv4']['address'] }}"
-        {% endif %}
-      {% endif %}
-      {% endfor %}
-     ]
+    {% set comma_nodes = joiner(", ") %}
+    {% for server in consul_servers %}
+      {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] }}"
+    {% endfor %}
+    ]
 }

--- a/templates/config_client.json.j2
+++ b/templates/config_client.json.j2
@@ -10,12 +10,10 @@
     "ports": {{ consul_ports | to_nice_json }},
   {% endif -%}
   {% if consul_recursors|length > 0 -%}
-    "recursors": [
-      {%- set comma = joiner(", ") -%}
+    "recursors": [ {% set comma = joiner(", ") -%}
       {% for recursor in consul_recursors -%}
         {{ comma() }}"{{ recursor }}"
-      {%- endfor -%}
-    ],
+      {%- endfor %} ],
   {% endif -%}
   "bootstrap": false,
   "server": false,
@@ -25,10 +23,8 @@
   "encrypt": "{{ consul_raw_key }}",
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
-  "start_join": [
-    {%- set comma_nodes = joiner(", ") -%}
+  "start_join": [ {% set comma_nodes = joiner(", ") -%}
     {% for server in consul_servers -%}
       {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] }}"
-    {%- endfor -%}
-  ]
+    {%- endfor %} ]
 }

--- a/templates/config_client.json.j2
+++ b/templates/config_client.json.j2
@@ -6,6 +6,9 @@
     "https": "{{ consul_https_bind_address }}",
     "rpc": "{{ consul_rpc_bind_address }}"
   },
+  {% if consul_ports %}
+  "ports": {{ consul_ports | to_nice_json }},
+  {% endif %}
   {%- if consul_recursors|length > 0 -%}
   "recursors": [
     {% set comma = joiner(", ") %}
@@ -13,9 +16,6 @@
       {{ comma() }}"{{ recursor }}"
     {%- endfor %}
     ],
-  {% endif %}
-  {% if consul_ports %}
-  "ports": {{ consul_ports | to_nice_json }},
   {% endif %}
   "bootstrap": false,
   "server": false,

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -1,6 +1,3 @@
-{% set comma = joiner(", ") %}
-{% set comma_nodes = joiner(", ") %}
-
 {
   "bind_addr": "{{ consul_bind_address }}",
   "addresses": {
@@ -13,10 +10,12 @@
   "ports": {{ consul_ports | to_nice_json }},
   {% endif %}
   {%- if consul_recursors|length > 0 -%}
-  "recursors": [ {% for recursor in consul_recursors -%}
-                     {{ comma() }}"{{ recursor }}"
-                 {%- endfor %} ],
-  {% endif %}
+  "recursors": [
+    {% set comma = joiner(", ") %}
+    {% for recursor in consul_recursors -%}
+      {{ comma() }}"{{ recursor }}"
+    {%- endfor %}
+    ],
   "bootstrap": false,
   "server": true,
   "node_name": "{{ consul_node_name }}",
@@ -26,18 +25,10 @@
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
   "start_join": [
-    {% set interface = 'ansible_' ~ consul_iface %}
-    {% for host in groups[consul_group_name] %}
-    {% if ansible_system == 'FreeBSD' %}
-      {% if host != inventory_hostname and (hostvars[host]['consul_node_role'] == 'server' or hostvars[host]['consul_node_role'] == 'bootstrap') %}
-      {{ comma_nodes() }}"{{ hostvars[host][interface]['ipv4'][0]['address'] }}"
-      {% endif %}
-    {% else %}
-      {% if host != inventory_hostname and (hostvars[host]['consul_node_role'] == 'server' or hostvars[host]['consul_node_role'] == 'bootstrap') %}
-      {{ comma_nodes() }}"{{ hostvars[host][interface]['ipv4']['address'] }}"
-      {% endif %}
-    {% endif %}
+    {% set comma_nodes = joiner(", ") %}
+    {% for server in consul_servers %}
+      {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] }}"
     {% endfor %}
-   ],
+    ],
   "ui": true
 }

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -10,12 +10,10 @@
     "ports": {{ consul_ports | to_nice_json }},
   {% endif -%}
   {% if consul_recursors|length > 0 -%}
-    "recursors": [
-      {%- set comma = joiner(", ") -%}
+    "recursors": [ {% set comma = joiner(", ") -%}
       {% for recursor in consul_recursors -%}
         {{ comma() }}"{{ recursor }}"
-      {%- endfor -%}
-    ],
+      {%- endfor %} ],
   {% endif -%}
   "bootstrap": false,
   "server": true,
@@ -25,11 +23,9 @@
   "encrypt": "{{ consul_raw_key }}",
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
-  "start_join": [
-    {%- set comma_nodes = joiner(", ") -%}
+  "start_join": [ {% set comma_nodes = joiner(", ") -%}
     {% for server in consul_servers -%}
       {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] }}"
-    {%- endfor -%}
-  ],
+    {%- endfor %} ],
   "ui": true
 }

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -6,17 +6,17 @@
     "https": "{{ consul_https_bind_address }}",
     "rpc": "{{ consul_rpc_bind_address }}"
   },
-  {% if consul_ports %}
-  "ports": {{ consul_ports | to_nice_json }},
-  {% endif %}
-  {%- if consul_recursors|length > 0 -%}
-  "recursors": [
-    {% set comma = joiner(", ") %}
-    {% for recursor in consul_recursors -%}
-      {{ comma() }}"{{ recursor }}"
-    {%- endfor %}
+  {% if consul_ports -%}
+    "ports": {{ consul_ports | to_nice_json }},
+  {% endif -%}
+  {% if consul_recursors|length > 0 -%}
+    "recursors": [
+      {%- set comma = joiner(", ") -%}
+      {% for recursor in consul_recursors -%}
+        {{ comma() }}"{{ recursor }}"
+      {%- endfor -%}
     ],
-  {% endif %}
+  {% endif -%}
   "bootstrap": false,
   "server": true,
   "node_name": "{{ consul_node_name }}",
@@ -26,10 +26,10 @@
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
   "start_join": [
-    {% set comma_nodes = joiner(", ") %}
-    {% for server in consul_servers %}
+    {%- set comma_nodes = joiner(", ") -%}
+    {% for server in consul_servers -%}
       {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] }}"
-    {% endfor %}
-    ],
+    {%- endfor -%}
+  ],
   "ui": true
 }

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -16,6 +16,7 @@
       {{ comma() }}"{{ recursor }}"
     {%- endfor %}
     ],
+  {% endif %}
   "bootstrap": false,
   "server": true,
   "node_name": "{{ consul_node_name }}",

--- a/templates/consul_smf_manifest.j2
+++ b/templates/consul_smf_manifest.j2
@@ -8,7 +8,7 @@
     <service name="network/consul" type="service" version="1">
 
         <create_default_instance enabled="false"/>
-        
+
         <single_instance/>
 
         <dependency name="network" grouping="require_all" restart_on="error" type="service">
@@ -33,11 +33,11 @@
 
             <propval name="ignore_error" type="astring" value="core,signal"/>
         </property_group>
+
         <property_group name="application" type="application">
             <propval name="config_dir" type="astring" value="{{ consul_config_path }}/{{ consul_node_role }}"/>
         </property_group>
-        
-        
+
         <stability value="Evolving"/>
 
         <template>


### PR DESCRIPTION
Lot's of cleanup, tweaks and improvements in this PR.

Did a cleanup of the templates to produce cleaner output. Also added the `consul_servers` variable to make it easier to loop over them in the templates.

Did some cleanup in the defaults file, and changed to default value of `consul_iface` to always contain a valid interface by default (see comment in #40 )

Added the 'gather server facts' task to discover the `consul_bind_address` from servers that are currently not targeted (not used by default). Also fixed the `consul_bind_address` default value so it works on FreeBSD again.

It's now possible to bootstrap a client or server by only targeting that node if the 'gather server facts' task is enabled or all servers have there `consul_bind_address` set in there hostvars file/the inventory. (And the gossip key is provided in host/group vars or env.)

Added *client* as default for the `consul_node_role` as it makes sense to bootstrap a client by default.

Added a switch (default *True*) for the user management task and placed it in it's own file. Also hinted on more configurable group management for the future.

Moved the `vault_address` var to the consul namespace (`consul_vault_address`) with a default value of `vault_address | default ('0.0.0.0', true)`. This preserves the current behavior but makes it possible to have a different vault address for consul then the default vault setup for the node.

Moved directory settings to there own file.