### PR TITLE
ipwrap start_join list

### DIFF
--- a/templates/config_client.json.j2
+++ b/templates/config_client.json.j2
@@ -25,6 +25,6 @@
   "enable_syslog": {{ consul_syslog_enable|lower }},
   "start_join": [ {% set comma_nodes = joiner(", ") -%}
     {% for server in consul_servers -%}
-      {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] }}"
+      {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] | ipwrap }}"
     {%- endfor %} ]
 }

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -25,7 +25,7 @@
   "enable_syslog": {{ consul_syslog_enable|lower }},
   "start_join": [ {% set comma_nodes = joiner(", ") -%}
     {% for server in consul_servers -%}
-      {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] }}"
+      {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] | ipwrap }}"
     {%- endfor %} ],
   "ui": true
 }


### PR DESCRIPTION
Consul wants square brackets around IPv6 addresses in the `start_join` list, but doesn’t like them in `bind_addr`.

This change adds the [ipwrap](http://docs.ansible.com/ansible/playbooks_filters_ipaddr.html) filter to wrap IPv6 addresses in square brackets.