### PR TITLE
Add bootstrap-expect toggle option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,8 @@ consul_iface: "{{ lookup('env','CONSUL_IFACE') | default(ansible_default_ipv4.in
 consul_node_name: "{{ inventory_hostname_short }}"
 consul_node_role: "{{ lookup('env','CONSUL_NODE_ROLE') | default('client', true) }}"
 consul_recursors: "{{ lookup('env','CONSUL_RECURSORS') | default('[]', true) }}"
+consul_bootstrap_expect: "{{ lookup('env','CONSUL_BOOTSTRAP_EXPECT') | default(false, true) }}"
+
 
 ### Addresses
 consul_bind_address: "\

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -60,3 +60,16 @@
   when:
     - consul_iptables_enable
     - consul_recursors|length == 0
+
+- name: Fail if more then one bootstrap server is defined
+  fail:
+    msg: "You can not define more then one bootstrap server."
+  when:
+    - _consul_bootstrap_servers|length > 1
+
+- name: Fail if a bootstrap server is defined and bootstrap_expect is true
+  fail:
+    msg: "Can't use a bootstrap server and bootstrap_expect at the same time."
+  when:
+    - _consul_bootstrap_servers|length > 0
+    - consul_bootstrap_expect|bool

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -16,6 +16,9 @@
       {%- endfor %} ],
   {% endif -%}
   "bootstrap": false,
+  {% if consul_bootstrap_expect -%}
+    "bootstrap_expect": {{ consul_servers|length }},
+  {% endif -%}
   "server": true,
   "node_name": "{{ consul_node_name }}",
   "datacenter": "{{ consul_datacenter }}",

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,11 @@
+# Pure internal helper variables
+_consul_bootstrap_servers: "\
+  {% set __consul_bootstrap_servers = [] %}\
+  {% for host in groups[consul_group_name] %}\
+    {% set _consul_node_role = hostvars[host]['consul_node_role']|default('client', true) %}\
+    {% if _consul_node_role == 'bootstrap' %}\
+      {% if __consul_bootstrap_servers.append(host) %}{% endif %}\
+    {% endif %}\
+  {% endfor %}\
+  {{ __consul_bootstrap_servers }}"
+_consul_bootstrap_server: "{{ _consul_bootstrap_servers[0] }}"


### PR DESCRIPTION
Closes #54 

Adds an option to bootstrap using the `bootstrap_expect` option instead of a bootstrap server (using the `bootstrap` option).

Defaults to using a bootstrap server for now, we could still change this.

Also adds some internal variables (`_consul_bootstrap_servers` and `_consul_bootstrap_server`) for internal usage. Currently only used for two new asserts that check if there's max 1 bootstrap server and no bootstrap servers are defined while the `bootstrap_expect` option is used.