### PR TITLE
Generate correct JSON with TLS and ACL enabled

### DIFF
--- a/templates/config_bootstrap.json.j2
+++ b/templates/config_bootstrap.json.j2
@@ -24,19 +24,19 @@
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
   "domain": "{{ consul_domain }}",
-  "ui": true
   {% if consul_tls_enable -%}
     "ca_file": "{{ consul_tls_dir }}/{{ consul_tls_ca_crt }}",
     "cert_file": "{{ consul_tls_dir }}/{{ consul_tls_server_crt }}",
     "key_file": "{{ consul_tls_dir }}/{{ consul_server_key }}",
     "verify_incoming": {{ consul_tls_verify_incoming | to_json }},
-    "verify_outgoing": {{ consul_tls_verify_outgoing | to_json }}
+    "verify_outgoing": {{ consul_tls_verify_outgoing | to_json }},
   {% endif -%}
   {% if consul_acl_enable -%}
     "acl_datacenter": "{{ consul_acl_datacenter }}",
     "acl_default_policy": "{{ consul_acl_default_policy }}",
     "acl_down_policy": "{{ consul_acl_down_policy }}",
     "acl_master_token": "{{ consul_acl_master_token }}",
-    "acl_replication_token": "{{ consul_acl_replication_token }}"
+    "acl_replication_token": "{{ consul_acl_replication_token }}",
   {% endif -%}
+  "ui": true
 }


### PR DESCRIPTION
This is more or less a dirty hack, maybe Jinja has a better way to append json and conditionally add the comma after `"ui": true`.