### PR TITLE
Multi datacenter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ the variables are named and described below:
 ### `consul_os`
 
 - Node operating system name in lowercase representation
-- Default value: `{{ ansible_os_family|lower }}`
+- Default value: `{{ ansible_os_family | lower }}`
 
 ### `consul_zip_url`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ consul_architecture_map:
   armv7l: arm
   aarch64: arm64
 consul_architecture: "{{ consul_architecture_map[ansible_architecture] }}"
-consul_os: "{{ ansible_system|lower }}"
+consul_os: "{{ ansible_system | lower }}"
 consul_pkg: "consul_{{ consul_version }}_{{ consul_os }}_{{ consul_architecture }}.zip"
 consul_zip_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_{{ consul_os }}_{{ consul_architecture }}.zip"
 consul_checksum_file_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version}}_SHA256SUMS"
@@ -74,7 +74,7 @@ consul_group_name: "{{ lookup('env','CONSUL_GROUP_NAME') | default('cluster_node
 consul_servers: "\
   {% set _consul_servers = [] %}\
   {% for host in groups[consul_group_name] %}\
-    {% set _consul_node_role = hostvars[host]['consul_node_role']|default('client', true) %}\
+    {% set _consul_node_role = hostvars[host]['consul_node_role'] | default('client', true) %}\
     {% if ( _consul_node_role == 'server' or _consul_node_role == 'bootstrap') %}\
       {% if _consul_servers.append(host) %}{% endif %}\
     {% endif %}\

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -11,28 +11,28 @@
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution in ['RedHat', 'CentOS']
-    - ansible_distribution_version|version_compare(6, '<')
+    - ansible_distribution_version | version_compare(6, '<')
 
 - name: Check Debian version
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "Debian"
-    - ansible_distribution_version|version_compare(8, '<')
+    - ansible_distribution_version | version_compare(8, '<')
 
 - name: Check FreeBSD version
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "FreeBSD"
-    - ansible_distribution_version|version_compare(10, '<')
+    - ansible_distribution_version | version_compare(10, '<')
 
 - name: Check Ubuntu version
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "Ubuntu"
-    - ansible_distribution_version|version_compare(13.04, '<')
+    - ansible_distribution_version | version_compare(13.04, '<')
 
 - name: Check specified ethernet interface
   fail:
@@ -45,7 +45,7 @@
   when:
     - consul_iptables_enable | bool
     - ansible_distribution in ['RedHat', 'CentOS']
-    - ansible_distribution_version|version_compare(6, '>=')
+    - ansible_distribution_version | version_compare(6, '>=')
 
 - name: Check for both Dnsmasq and iptables enabled
   fail:
@@ -59,13 +59,13 @@
     msg: "Recursors are required if iptables is enabled."
   when:
     - consul_iptables_enable | bool
-    - consul_recursors|length == 0
+    - consul_recursors | length == 0
 
 - name: Fail if more then one bootstrap server is defined
   fail:
     msg: "You can not define more then one bootstrap server."
   when:
-    - _consul_bootstrap_servers|length > 1
+    - _consul_bootstrap_servers | length > 1
 
 - name: Fail if a bootstrap server is defined and bootstrap_expect is true
   fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   setup:
   delegate_to: "{{ item }}"
   delegate_facts: True
-  with_items: "{{ consul_servers|difference(play_hosts) }}"
+  with_items: "{{ consul_servers | difference(play_hosts) }}"
   ignore_errors: yes
   when: consul_gather_server_facts | bool
 
@@ -200,13 +200,13 @@
   - name: Import smf manifest
     shell: "svccfg import {{ consul_smf_manifest }}"
     when:
-      - smfmanifest|changed
+      - smfmanifest | changed
       - ansible_os_family == "Solaris"
 
   - name: Import smf script
     shell: "svcadm refresh consul"
     when:
-      - smfmanifest|changed
+      - smfmanifest | changed
       - ansible_os_family == "Solaris"
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,9 +19,10 @@
   ignore_errors: yes
   when: consul_gather_server_facts | bool
 
-- name: Expose consul_bind_address and consul_node_role as facts
+- name: Expose bind_address, datacenter and node_role as facts
   set_fact:
     consul_bind_address: "{{ consul_bind_address }}"
+    consul_datacenter: "{{ consul_datacenter }}"
     consul_node_role: "{{ consul_node_role }}"
 
 - name: Read bootstrapped state

--- a/templates/config_bootstrap.json.j2
+++ b/templates/config_bootstrap.json.j2
@@ -38,5 +38,11 @@
     "acl_master_token": "{{ consul_acl_master_token }}",
     "acl_replication_token": "{{ consul_acl_replication_token }}",
   {% endif -%}
+  {% if _consul_wan_servers | length > 0 -%}
+    "start_join_wan": [ {% set comma_nodes = joiner(", ") -%}
+        {% for server in _consul_wan_servers -%}
+        {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] | ipwrap }}"
+        {%- endfor %} ],
+  {% endif -%}
   "ui": true
 }

--- a/templates/config_bootstrap.json.j2
+++ b/templates/config_bootstrap.json.j2
@@ -9,7 +9,7 @@
   {% if consul_ports -%}
     "ports": {{ consul_ports | to_nice_json }},
   {% endif -%}
-  {% if consul_recursors|length > 0 -%}
+  {% if consul_recursors | length > 0 -%}
     "recursors": [ {% set comma = joiner(", ") -%}
       {% for recursor in consul_recursors -%}
         {{ comma() }}"{{ recursor }}"
@@ -22,7 +22,7 @@
   "data_dir": "{{ consul_data_path }}",
   "encrypt": "{{ consul_raw_key }}",
   "log_level": "{{ consul_log_level }}",
-  "enable_syslog": {{ consul_syslog_enable|lower }},
+  "enable_syslog": {{ consul_syslog_enable | lower }},
   "domain": "{{ consul_domain }}",
   {% if consul_tls_enable -%}
     "ca_file": "{{ consul_tls_dir }}/{{ consul_tls_ca_crt }}",

--- a/templates/config_client.json.j2
+++ b/templates/config_client.json.j2
@@ -9,7 +9,7 @@
   {% if consul_ports -%}
     "ports": {{ consul_ports | to_nice_json }},
   {% endif -%}
-  {% if consul_recursors|length > 0 -%}
+  {% if consul_recursors | length > 0 -%}
     "recursors": [ {% set comma = joiner(", ") -%}
       {% for recursor in consul_recursors -%}
         {{ comma() }}"{{ recursor }}"
@@ -22,7 +22,7 @@
   "data_dir": "{{ consul_data_path }}",
   "encrypt": "{{ consul_raw_key }}",
   "log_level": "{{ consul_log_level }}",
-  "enable_syslog": {{ consul_syslog_enable|lower }},
+  "enable_syslog": {{ consul_syslog_enable | lower }},
   "start_join": [ {% set comma_nodes = joiner(", ") -%}
     {% for server in consul_servers -%}
       {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] | ipwrap }}"

--- a/templates/config_client.json.j2
+++ b/templates/config_client.json.j2
@@ -24,7 +24,7 @@
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable | lower }},
   "start_join": [ {% set comma_nodes = joiner(", ") -%}
-    {% for server in consul_servers -%}
+    {% for server in _consul_lan_servers -%}
       {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] | ipwrap }}"
     {%- endfor %} ]
 }

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -17,7 +17,7 @@
   {% endif -%}
   "bootstrap": false,
   {% if consul_bootstrap_expect -%}
-    "bootstrap_expect": {{ consul_servers|length }},
+    "bootstrap_expect": {{ _consul_lan_servers|length }},
   {% endif -%}
   "server": true,
   "node_name": "{{ consul_node_name }}",
@@ -27,8 +27,14 @@
   "log_level": "{{ consul_log_level }}",
   "enable_syslog": {{ consul_syslog_enable|lower }},
   "start_join": [ {% set comma_nodes = joiner(", ") -%}
-    {% for server in consul_servers -%}
+    {% for server in _consul_lan_servers -%}
       {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] | ipwrap }}"
     {%- endfor %} ],
+  {% if _consul_wan_servers|length > 0 -%}
+    "start_join_wan": [ {% set comma_nodes = joiner(", ") -%}
+        {% for server in _consul_wan_servers -%}
+        {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] | ipwrap }}"
+        {%- endfor %} ],
+  {% endif -%}
   "ui": true
 }

--- a/templates/config_server.json.j2
+++ b/templates/config_server.json.j2
@@ -9,7 +9,7 @@
   {% if consul_ports -%}
     "ports": {{ consul_ports | to_nice_json }},
   {% endif -%}
-  {% if consul_recursors|length > 0 -%}
+  {% if consul_recursors | length > 0 -%}
     "recursors": [ {% set comma = joiner(", ") -%}
       {% for recursor in consul_recursors -%}
         {{ comma() }}"{{ recursor }}"
@@ -17,7 +17,7 @@
   {% endif -%}
   "bootstrap": false,
   {% if consul_bootstrap_expect -%}
-    "bootstrap_expect": {{ _consul_lan_servers|length }},
+    "bootstrap_expect": {{ _consul_lan_servers | length }},
   {% endif -%}
   "server": true,
   "node_name": "{{ consul_node_name }}",
@@ -25,12 +25,12 @@
   "data_dir": "{{ consul_data_path }}",
   "encrypt": "{{ consul_raw_key }}",
   "log_level": "{{ consul_log_level }}",
-  "enable_syslog": {{ consul_syslog_enable|lower }},
+  "enable_syslog": {{ consul_syslog_enable | lower }},
   "start_join": [ {% set comma_nodes = joiner(", ") -%}
     {% for server in _consul_lan_servers -%}
       {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] | ipwrap }}"
     {%- endfor %} ],
-  {% if _consul_wan_servers|length > 0 -%}
+  {% if _consul_wan_servers | length > 0 -%}
     "start_join_wan": [ {% set comma_nodes = joiner(", ") -%}
         {% for server in _consul_wan_servers -%}
         {{ comma_nodes() }}"{{ hostvars[server]['consul_bind_address'] | ipwrap }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,14 +1,4 @@
 # Pure internal helper variables
-_consul_bootstrap_servers: "\
-  {% set __consul_bootstrap_servers = [] %}\
-  {% for server in consul_servers %}\
-    {% set _consul_node_role = hostvars[server]['consul_node_role']|default('client', true) %}\
-    {% if _consul_node_role == 'bootstrap' %}\
-      {% if __consul_bootstrap_servers.append(server) %}{% endif %}\
-    {% endif %}\
-  {% endfor %}\
-  {{ __consul_bootstrap_servers }}"
-_consul_bootstrap_server: "{{ _consul_bootstrap_servers[0] }}"
 
 _consul_lan_servers: "\
   {% set __consul_lan_servers = [] %}\
@@ -29,3 +19,14 @@ _consul_wan_servers: "\
     {% endif %}\
   {% endfor %}\
   {{ __consul_wan_servers }}"
+
+_consul_bootstrap_servers: "\
+  {% set __consul_bootstrap_servers = [] %}\
+  {% for server in _consul_lan_servers %}\
+    {% set _consul_node_role = hostvars[server]['consul_node_role']|default('client', true) %}\
+    {% if _consul_node_role == 'bootstrap' %}\
+      {% if __consul_bootstrap_servers.append(server) %}{% endif %}\
+    {% endif %}\
+  {% endfor %}\
+  {{ __consul_bootstrap_servers }}"
+_consul_bootstrap_server: "{{ _consul_bootstrap_servers[0] }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 _consul_lan_servers: "\
   {% set __consul_lan_servers = [] %}\
   {% for server in consul_servers %}\
-    {% set _consul_datacenter = hostvars[server]['consul_datacenter']|default('dc1', true) %}\
+    {% set _consul_datacenter = hostvars[server]['consul_datacenter'] | default('dc1', true) %}\
     {% if _consul_datacenter == consul_datacenter %}\
       {% if __consul_lan_servers.append(server) %}{% endif %}\
     {% endif %}\
@@ -13,7 +13,7 @@ _consul_lan_servers: "\
 _consul_wan_servers: "\
   {% set __consul_wan_servers = [] %}\
   {% for server in consul_servers %}\
-    {% set _consul_datacenter = hostvars[server]['consul_datacenter']|default('dc1', true) %}\
+    {% set _consul_datacenter = hostvars[server]['consul_datacenter'] | default('dc1', true) %}\
     {% if _consul_datacenter != consul_datacenter %}\
       {% if __consul_wan_servers.append(server) %}{% endif %}\
     {% endif %}\
@@ -23,7 +23,7 @@ _consul_wan_servers: "\
 _consul_bootstrap_servers: "\
   {% set __consul_bootstrap_servers = [] %}\
   {% for server in _consul_lan_servers %}\
-    {% set _consul_node_role = hostvars[server]['consul_node_role']|default('client', true) %}\
+    {% set _consul_node_role = hostvars[server]['consul_node_role'] | default('client', true) %}\
     {% if _consul_node_role == 'bootstrap' %}\
       {% if __consul_bootstrap_servers.append(server) %}{% endif %}\
     {% endif %}\

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,11 +1,31 @@
 # Pure internal helper variables
 _consul_bootstrap_servers: "\
   {% set __consul_bootstrap_servers = [] %}\
-  {% for host in groups[consul_group_name] %}\
-    {% set _consul_node_role = hostvars[host]['consul_node_role']|default('client', true) %}\
+  {% for server in consul_servers %}\
+    {% set _consul_node_role = hostvars[server]['consul_node_role']|default('client', true) %}\
     {% if _consul_node_role == 'bootstrap' %}\
-      {% if __consul_bootstrap_servers.append(host) %}{% endif %}\
+      {% if __consul_bootstrap_servers.append(server) %}{% endif %}\
     {% endif %}\
   {% endfor %}\
   {{ __consul_bootstrap_servers }}"
 _consul_bootstrap_server: "{{ _consul_bootstrap_servers[0] }}"
+
+_consul_lan_servers: "\
+  {% set __consul_lan_servers = [] %}\
+  {% for server in consul_servers %}\
+    {% set _consul_datacenter = hostvars[server]['consul_datacenter']|default('dc1', true) %}\
+    {% if _consul_datacenter == consul_datacenter %}\
+      {% if __consul_lan_servers.append(server) %}{% endif %}\
+    {% endif %}\
+  {% endfor %}\
+  {{ __consul_lan_servers }}"
+
+_consul_wan_servers: "\
+  {% set __consul_wan_servers = [] %}\
+  {% for server in consul_servers %}\
+    {% set _consul_datacenter = hostvars[server]['consul_datacenter']|default('dc1', true) %}\
+    {% if _consul_datacenter != consul_datacenter %}\
+      {% if __consul_wan_servers.append(server) %}{% endif %}\
+    {% endif %}\
+  {% endfor %}\
+  {{ __consul_wan_servers }}"


### PR DESCRIPTION
Adds some extra internal variables to differentiate between lan servers and wan servers. This allows for basic multi-datacenter support.

Hosts in the same group will use the same encryption key. Defining multiple datacenters in the same group results in multiple auto joining datacenters.