### PR TITLE
update (set ownership of) consul folders recursively

### DIFF
--- a/tasks/dirs.yml
+++ b/tasks/dirs.yml
@@ -7,6 +7,7 @@
     state: directory
     owner: "{{ consul_user }}"
     group: "{{ consul_group}}"
+    recurse: yes
   with_items:
     - "{{ consul_config_path }}"
     - "{{ consul_configd_path }}"


### PR DESCRIPTION
This playbook creates (or updates existing) several folders for Consul and sets ownership to consul user and group.

Files inside those folders  (for example keyring files) should be updated too by executing the Ansible task with "recursive" option.