### PR TITLE
improve HTTP API check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -232,10 +232,17 @@
           state: started
           enabled: yes
 
-      - name: Check Consul HTTP API
+      - name: Check Consul HTTP API (via TCP socket)
         wait_for:
           delay: 15
-          port: 8500
+          port: "{{consul_ports.http|int}}"
+        when: (consul_ports.http|int > -1) and (consul_http_bind_address|ipaddr)
+
+      - name: Check Consul HTTP API (via unix socket)
+        wait_for:
+          delay: 15
+          path: consul_http_bind_address
+        when: consul_http_bind_address | match("unix:/*")
 
       - name: Create bootstrapped state file
         file:


### PR DESCRIPTION
The check whether Consul had started failed when `consul_ports.http` was set to something other than 8500. It also failed, if you set the `consul_http_bind_address` to a Unix socket path.

This improves the check in *NIX block in `tasks/main.yml` by wrapping it in a conditional:

- if `consul_ports.http` > 0, *and* `consul_http_bind_address` is a valid IP address, use `wait_for`+`port`
- if `consul_http_bind_address` starts with `unix:/`, use `wait_for`+`path`