### PR TITLE
Fix runtime warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,6 @@ in many Ansible versions, so this feature might not always work.
 - HTTPS API bind address
 - Default value: *0.0.0.0*
 
-### `consul_rpc_bind_address`
-
-- RPC bind address
-- Default value: *0.0.0.0*
-
 ### `consul_ports`
 
 - Port Mappings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,6 @@ consul_bind_address: "\
 consul_dns_bind_address: "127.0.0.1"
 consul_http_bind_address: "0.0.0.0"
 consul_https_bind_address: "0.0.0.0"
-consul_rpc_bind_address: "0.0.0.0"
 consul_vault_address: "{{ vault_address | default('0.0.0.0', true) }}"
 
 ### Ports

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,7 +79,6 @@ consul_vault_address: "{{ vault_address | default('0.0.0.0', true) }}"
 
 ### Ports
 consul_ports:
-  rpc: 8400
   http: 8500
   https: -1
   dns: 8600

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -14,7 +14,6 @@
         "dns": "{{ consul_dns_bind_address }}",
         "http": "{{ consul_http_bind_address }}",
         "https": "{{ consul_https_bind_address }}",
-        "rpc": "{{ consul_rpc_bind_address }}",
     },
     {% if consul_ports %}
         "ports": {{ consul_ports | to_json }},


### PR DESCRIPTION
Those warnings were observed with :

    # consul --version
    Consul v0.8.4
