### PR TITLE
Fix "Check Consul HTTP API (via unix socket)"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -241,8 +241,8 @@
       - name: Check Consul HTTP API (via unix socket)
         wait_for:
           delay: 15
-          path: consul_http_bind_address
-        when: consul_http_bind_address | match("unix:/*")
+          path: "{{ consul_http_bind_address | replace('unix://', '', 1) }}"
+        when: consul_http_bind_address | match("unix://*")
 
       - name: Create bootstrapped state file
         file:


### PR DESCRIPTION
a unix domain socket is represented by an URI starting with "unix://"
followed by a file path, strip the URI prefix before checking for file existence

Before the fix defining a node like the following:
```
[cluster_nodes]
192.168.1.159 consul_node_role=server consul_node_name=c1s consul_http_bind_address="unix:///var/run/consul/consul.sock"
```
Made the test fail with error message (from memory): `timeout connecting to unix socket consul_http_bind_address`, now it passes with:
```
TASK [ansible-consul : Check Consul HTTP API (via unix socket)] ******************************************************************************************************************************
ok: [192.168.1.159]
```
