### PR TITLE
Support Upgrading Consul #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,13 @@ in many Ansible versions, so this feature might not always work.
 - This is the only option on Windows as WinRM is somewhat limited in this scope
 - Default value: *false*
 
+### `consul_install_upgrade`
+
+- Whether to [upgrade consul](https://www.consul.io/docs/upgrading.html) when a new version is specified
+- The role does not handle the orchestration of a rolling update of servers followed by client nodes
+- This option is not available for Windows, yet. (PR welcome)
+- Default value: *false*
+
 ### `consul_ui`
 
 - Enable the consul ui?

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ consul_checksum_file_url: "https://releases.hashicorp.com/consul/{{ consul_versi
 
 ### Install Method
 consul_install_remotely: false
+consul_install_upgrade: false
 
 ### Paths
 consul_bin_path: "/usr/local/bin"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -58,6 +58,14 @@
     mode: 0755
   tags: installation
 
+- name: Daemon reload systemd in case the binaries upgraded
+  command: systemctl daemon-reload
+  become: yes
+  notify: restart consul
+  when:
+    - ansible_service_mgr == "systemd"
+    - consul_install_upgrade
+
 - name: Cleanup
   local_action: file path="{{ item }}" state="absent"
   become: no

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -56,6 +56,14 @@
     mode: 0755
   tags: installation
 
+- name: Daemon reload systemd in case the binaries upgraded
+  command: systemctl daemon-reload
+  become: yes
+  notify: restart consul
+  when:
+    - ansible_service_mgr == "systemd"
+    - consul_install_upgrade
+
 - name: Cleanup
   file:
     path: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,16 +59,20 @@
         path: "{{ consul_binary }}"
       register: consul_binary_installed
 
+    - name: Calculate whether to install consul binary
+      set_fact:
+        consul_install_binary: "{{ consul_install_upgrade or not consul_binary_installed.stat.exists }}"
+
     - name: Install OS packages and consul - locally
       include: install.yml
       when:
-        - not consul_binary_installed.stat.exists | bool
+        - consul_install_binary | bool
         - not consul_install_remotely | bool
 
     - name: Install OS packages and consul - remotely
       include: install_remote.yml
       when:
-        - not consul_binary_installed.stat.exists | bool
+        - consul_install_binary | bool
         - consul_install_remotely | bool
 
     # XXX: Individual gossip tasks are deprecated and need to be removed


### PR DESCRIPTION
This is the described consul_install_upgrade variable, which successfully upgraded consul on systemd.

The guide from hashicorp discusses a rolling upgrade of server and then client nodes, but the atomisation of this inside the role feels wrong.

Note: The Windows code path is not touched by this PR. Somebody with knowledge of that platform should handle it.