### PR TITLE
Update config ACLs, Addresses and Ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,13 @@ ports can be done using the `consul_ports_*` variables.
 - Enable script based checks?
 - Default vaule: *false*
 
+### `consul_raft_protocol`
+
+- Raft protocol to use.
+- Default vaule:
+- `consul_version` <= `0.7.0`: *1*
+- `consul_version` > `0.7.0`: *3*
+
 ### `consul_node_role`
 
 - The Consul role of the node, one of: *bootstrap*, *server*, or *client*

--- a/README.md
+++ b/README.md
@@ -193,29 +193,47 @@ option has been problematic.
 
 - Bind address
   - Override with `CONSUL_BIND_ADDRESS` environment variable
-- Default value: *127.0.0.1*
+- Default value: default ipv4 address, or address of interface configured by
+  `consul_iface`
 
-### `consul_dns_bind_address`
+### `consul_advertise_address`
 
-- DNS API bind address
-- Default value: *127.0.0.1*
+- Lan advertise address
+- Default value: `consul_bind_address`
 
-### `consul_http_bind_address`
+### `consul_advertise_address_wan`
 
-- HTTP API bind address
-- Default value: *0.0.0.0*
+- Wan advertise address
+- Default value: `consul_bind_address`
 
-### `consul_https_bind_address`
+### `consul_advertise_addresses`
 
-- HTTPS API bind address
-- Default value: *0.0.0.0*
-
-### `consul_rpc_bind_address`
-
-- RPC bind address
+- Advanced advertise addresses settings
+- Individual addresses kan be overwritten using the `consul_advertise_addresses_*` variables
 - Default value:
-  - consul version < 0.8: *0.0.0.0*
-  - consul version >= 0.8: ""
+  ```yaml
+  consul_advertise_addresses:
+    serf_lan: "{{ consul_advertise_addresses_serf_lan | default(consul_advertise_address+':'+consul_ports.serf_lan) }}"
+    serf_wan: "{{ consul_advertise_addresses_serf_wan | default(consul_advertise_address_wan+':'+consul_ports.serf_wan) }}"
+    rpc: "{{ consul_advertise_addresses_rpc | default(consul_bind_address+':'+consul_ports.server) }}"
+  ```
+### `consul_client_address`
+
+- Client address
+- Default value: *127.0.0.1*
+
+### `consul_addresses`
+
+- Advanced address settings
+- Individual addresses kan be overwritten using the `consul_addresses_*` variables
+- Default value:
+  ```yaml
+  consul_addresses:
+    dns: "{{ consul_addresses_dns | default(consul_client_address, true) }}"
+    http: "{{ consul_addresses_http | default(consul_client_address, true) }}"
+    https: "{{ consul_addresses_https | default(consul_client_address, true) }}"
+    rpc: "{{ consul_addresses_rpc | default(consul_client_address, true) }}"
+  ```
 
 ### `consul_ports`
 
@@ -228,19 +246,24 @@ option has been problematic.
   - serf_lan - The Serf LAN port. Default 8301.
   - serf_wan - The Serf WAN port. Default 8302.
   - server - Server RPC address. Default 8300.
-- This variable expects a nested dict object that can directly be passed through `to_json` inside the template.
 
 For example, to enable the consul HTTPS API it is possible to set the variable as follows:
 
+- Default values:
 ```yaml
-  vars:
-    consul_ports:
-      dns: 8600
-      http: 8500
-      https: 8501
+  consul_ports:
+    dns: "{{ consul_ports_dns | default('8600', true) }}"
+    http: "{{ consul_ports_http | default('8500', true) }}"
+    https: "{{ consul_ports_https | default('-1', true) }}"
+    rpc: "{{ consul_ports_rpc | default('8400', true) }}"
+    serf_lan: "{{ consul_ports_serf_lan | default('8301', true) }}"
+    serf_wan: "{{ consul_ports_serf_wan | default('8302', true) }}"
+    server: "{{ consul_ports_server | default('8300', true) }}"
 ```
 
-Notice that the dict object has to use precisely the names stated in the documentation!
+Notice that the dict object has to use precisely the names stated in the
+documentation! And all ports must be specified. Overwriting one or multiple
+ports can be done using the `consul_ports_*` variables.
 
 ### `consul_node_name`
 

--- a/README.md
+++ b/README.md
@@ -271,11 +271,23 @@ Notice that the dict object has to use precisely the names stated in the documen
   - Override with `CONSUL_IPTABLES_ENABLE` environment variable
 - Default value: *false*
 
+### `consul_acl_policy`
+
+- Add basic ACL config file
+  - Override with `CONSUL_ACL_POLICY` environment variable
+- Default value: *false*
+
 ### `consul_acl_enable`
 
 - Enable ACLs
   - Override with `CONSUL_ACL_ENABLE` environment variable
 - Default value: *false*
+
+### `consul_acl_ttl`
+
+- TTL for ACL's
+  - Override with `CONSUL_ACL_TTL` environment variable
+- Default value: *30s*
 
 ### `consul_acl_datacenter`
 
@@ -283,16 +295,34 @@ Notice that the dict object has to use precisely the names stated in the documen
   - Override with `CONSUL_ACL_DATACENTER` environment variable
 - Default value: *dc1*
 
-### `consul_acl_default_policy`
-
-- Default ACL policy
-  - Override with `CONSUL_ACL_DEFAULT_POLICY` environment variable
-- Default value: *allow*
-
 ### `consul_acl_down_policy`
 
 - Default ACL down policy
   - Override with `CONSUL_ACL_DOWN_POLICY` environment variable
+- Default value: *allow*
+
+### `consul_acl_token`
+
+- Default ACL token, only set if provided
+  - Override with `CONSUL_ACL_TOKEN` environment variable
+- Default value: /
+
+### `consul_acl_agent_token`
+
+- Used for clients and servers to perform internal operations to the service catalog. See: [acl_agent_token](https://www.consul.io/docs/agent/options.html#acl_agent_token)
+  - Override with `CONSUL_ACL_AGENT_TOKEN` environment variable
+- Default value: /
+
+### `consul_acl_agent_master_token`
+
+- A [special access token](https://www.consul.io/docs/agent/options.html#acl_agent_master_token) that has agent ACL policy write privileges on each agent where it is configured
+  - Override with `CONSUL_ACL_AGENT_MASTER_TOKEN` environment variable
+- Default value: /
+
+### `consul_acl_default_policy`
+
+- Default ACL policy
+  - Override with `CONSUL_ACL_DEFAULT_POLICY` environment variable
 - Default value: *allow*
 
 ### `consul_acl_master_token`
@@ -307,22 +337,17 @@ Notice that the dict object has to use precisely the names stated in the documen
   - Override with `CONSUL_ACL_MASTER_TOKEN_DISPLAY` environment variable
 - Default value: *false*
 
+### `consul_acl_replication_enable`
+
+- Enable ACL replication without token (makes it possible to set the token
+  trough the API)
+  - Override with `CONSUL_ACL_REPLICATION_TOKEN_ENABLE` environment variable
+- Default value: /
+
 ### `consul_acl_replication_token`
 
 - ACL replication token
   - Override with `CONSUL_ACL_REPLICATION_TOKEN_DISPLAY` environment variable
-- Default value: *SN4K3OILSN4K3OILSN4K3OILSN4K3OIL*
-
-### `consul_acl_agent_token`
-
-- Used for clients and servers to perform internal operations to the service catalog. See: [acl_agent_token](https://www.consul.io/docs/agent/options.html#acl_agent_token)
-  - Override with `CONSUL_ACL_AGENT_TOKEN` environment variable
-- Default value: *SN4K3OILSN4K3OILSN4K3OILSN4K3OIL*
-
-### `consul_acl_agent_master_token`
-
-- A [special access token](https://www.consul.io/docs/agent/options.html#acl_agent_master_token) that has agent ACL policy write privileges on each agent where it is configured
-  - Override with `CONSUL_ACL_AGENT_MASTER_TOKEN` environment variable
 - Default value: *SN4K3OILSN4K3OILSN4K3OILSN4K3OIL*
 
 ### `consul_tls_enable`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,6 +63,12 @@ consul_recursors: "{{ lookup('env','CONSUL_RECURSORS') | default('[]', true) }}"
 consul_bootstrap_expect: "{{ lookup('env','CONSUL_BOOTSTRAP_EXPECT') | default(false, true) }}"
 consul_ui: "{{ lookup('env', 'CONSUL_UI') | default(true, true) }}"
 consul_enable_script_checks: no
+consul_raft_protocol: "\
+  {% if consul_version | version_compare('0.7.0', '<=') %}\
+    1\
+  {% else %}\
+    3\
+  {% endif %}"
 
 ### Addresses
 consul_bind_address: "\

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,13 +100,23 @@ consul_servers: "\
 consul_gather_server_facts: no
 
 ## ACL
+consul_acl_policy: false
+
+### Shared ACL config ###
 consul_acl_enable: "{{ lookup('env','CONSUL_ACL_ENABLE') | default(false, true) }}"
+consul_acl_ttl: "{{ lookup('env','CONSUL_ACL_TTL') | default('30s', true)}}"
 consul_acl_datacenter: "{{ lookup('env','CONSUL_ACL_DATACENTER') | default(consul_datacenter, true) }}"
+consul_acl_down_policy: "{{ lookup('env','CONSUL_ACL_DOWN_POLICY') | default('extend-cache', true) }}"
+consul_acl_token: "{{lookup('env','CONSUL_ACL_TOKEN') | default('', true) }}"
+consul_acl_agent_token: "{{ lookup('env','CONSUL_ACL_AGENT_TOKEN') | default('', true) }}"
+consul_acl_agent_master_token: "{{ lookup('env','CONSUL_ACL_AGENT_MASTER_TOKEN') | default('', true) }}"
+
+### Server ACL settings ###
 consul_acl_default_policy: "{{ lookup('env','CONSUL_ACL_DEFAULT_POLICY') | default('allow', true) }}"
 consul_acl_master_token: "{{ lookup('env','CONSUL_ACL_MASTER_TOKEN') | default('42424242-4242-4242-4242-424242424242', true) }}"
 consul_acl_master_token_display: "{{ lookup('env','CONSUL_ACL_MASTER_TOKEN_DISPLAY') | default(false, true) }}"
-consul_acl_replication_token_display: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN_DISPLAY') | default(false, true) }}"
-consul_acl_policy: false
+consul_acl_replication_enable: "{{ lookup('env','CONSUL_ACL_REPLICATION_ENABLE') | default('',true) }}"
+consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') | default('', true) }}"
 
 ## TLS
 consul_tls_enable: "{{ lookup('env','CONSUL_TLS_ENABLE') | default(false, true) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,18 +73,28 @@ consul_bind_address: "\
   {% else %}\
     {{ lookup('env','CONSUL_BIND_ADDRESS') | default(hostvars[inventory_hostname]['ansible_'+ consul_iface ]['ipv4']['address'], true) }}\
   {% endif %}"
-consul_dns_bind_address: "127.0.0.1"
-consul_http_bind_address: "0.0.0.0"
-consul_https_bind_address: "0.0.0.0"
-consul_rpc_bind_address: "0.0.0.0"
-consul_vault_address: "{{ vault_address | default('0.0.0.0', true) }}"
+consul_advertise_address: "{{ consul_bind_address }}"
+consul_advertise_address_wan: "{{ consul_bind_address }}"
+consul_advertise_addresses:
+  serf_lan: "{{ consul_advertise_addresses_serf_lan | default(consul_advertise_address+':'+consul_ports.serf_lan) }}"
+  serf_wan: "{{ consul_advertise_addresses_serf_wan | default(consul_advertise_address_wan+':'+consul_ports.serf_wan) }}"
+  rpc: "{{ consul_advertise_addresses_rpc | default(consul_bind_address+':'+consul_ports.server) }}"
+consul_client_address: '127.0.0.1'
+consul_addresses:
+  dns: "{{ consul_addresses_dns | default(consul_client_address, true) }}"
+  http: "{{ consul_addresses_http | default(consul_client_address, true) }}"
+  https: "{{ consul_addresses_https | default(consul_client_address, true) }}"
+  rpc: "{{ consul_addresses_rpc | default(consul_client_address, true) }}"
 
 ### Ports
 consul_ports:
-  rpc: 8400
-  http: 8500
-  https: -1
-  dns: 8600
+  dns: "{{ consul_ports_dns | default('8600', true) }}"
+  http: "{{ consul_ports_http | default('8500', true) }}"
+  https: "{{ consul_ports_https | default('-1', true) }}"
+  rpc: "{{ consul_ports_rpc | default('8400', true) }}"
+  serf_lan: "{{ consul_ports_serf_lan | default('8301', true) }}"
+  serf_wan: "{{ consul_ports_serf_wan | default('8302', true) }}"
+  server: "{{ consul_ports_server | default('8300', true) }}"
 
 ### Servers
 consul_group_name: "{{ lookup('env','CONSUL_GROUP_NAME') | default('consul_instances', true) }}"

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -14,7 +14,8 @@
     - not bootstrap_state.stat.exists | bool
 
 - name: Display ACL Master Token
-  debug: msg="{{ consul_acl_master_token }}"
+  debug:
+    msg: "{{ consul_acl_master_token }}"
   run_once: True
   when: consul_acl_master_token_display | bool
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -240,13 +240,14 @@
         wait_for:
           delay: 15
           port: "{{consul_ports.http|int}}"
-        when: (consul_ports.http|int > -1) and (consul_http_bind_address|ipaddr)
+          host: "{{ consul_addresses.http }}"
+        when: (consul_ports.http|int > -1) and (consul_addresses.http|ipaddr)
 
       - name: Check Consul HTTP API (via unix socket)
         wait_for:
           delay: 15
-          path: "{{ consul_http_bind_address | replace('unix://', '', 1) }}"
-        when: consul_http_bind_address | match("unix://*")
+          path: "{{ consul_addresses.http | replace('unix://', '', 1) }}"
+        when: consul_addresses.http | match("unix://*")
 
       - name: Create bootstrapped state file
         file:

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -10,43 +10,34 @@
 
     {## Addresses ##}
     "bind_addr": "{{ consul_bind_address }}",
+    "advertise_addr": "{{ consul_advertise_address }}",
+    "advertise_addr_wan": "{{ consul_advertise_address_wan }}",
+    "advertise_addrs": {
+        "serf_lan": "{{ consul_advertise_addresses.serf_lan }}",
+        "serf_wan": "{{ consul_advertise_addresses.serf_wan }}",
+        "rpc": "{{ consul_advertise_addresses.rpc }}",
+    },
+    "client_addr": "{{ consul_client_address }}",
     "addresses": {
-      {% if consul_dns_bind_address | trim != '' %}
-        "dns": "{{ consul_dns_bind_address }}",
-      {% endif %}
-      {% if consul_http_bind_address | trim != '' %}
-        "http": "{{ consul_http_bind_address }}",
-      {% endif %}
-      {% if consul_https_bind_address | trim != '' %}
-        "https": "{{ consul_https_bind_address }}",
-      {% endif %}
-      {% if consul_rpc_bind_address | trim != '' %}
-        "rpc": "{{ consul_rpc_bind_address }}",
-      {% endif %}
+        "dns": "{{ consul_addresses.dns }}",
+        "http": "{{ consul_addresses.http }}",
+        "https": "{{ consul_addresses.https }}",
+        {% if consul_version | version_compare('8.0', '<') %}
+            "rpc": "{{ consul_addresses.rpc }}",
+        {% endif %}
     },
     {## Ports Used ##}
-    {% if consul_ports | length > 0 %}
-      "ports": {{ consul_ports | to_json }},
-    {% else %}
-      "ports": {
-        {% if _consul_default_port_rpc | trim != '' %}
-          {% set _ = consul_ports.__setitem__('rpc', _consul_default_port_rpc) %}
-          "rpc": "{{ _consul_default_port_rpc }}",
+    "ports": {
+        "dns": {{ consul_ports.dns }},
+        "http": {{ consul_ports.http }},
+        "https": {{ consul_ports.https }},
+        {% if consul_version | version_compare('8.0', '<') %}
+            "rpc": {{ consul_ports.rpc}},
         {% endif %}
-        {% if _consul_default_port_http | trim != '' %}
-          {% set _ = consul_ports.__setitem__('http', _consul_default_port_http) %}
-          "http": "{{ _consul_default_port_http }}",
-        {% endif %}
-        {% if _consul_default_port_https | trim != '' %}
-          {% set _ = consul_ports.__setitem__('https', _consul_default_port_https) %}
-          "https": "{{ _consul_default_port_https }}",
-        {% endif %}
-        {% if _consul_default_port_dns | trim != '' %}
-          {% set _ = consul_ports.__setitem__('dns', _consul_default_port_dns) %}
-          "dns": "{{ _consul_default_port_dns }}",
-        {% endif %}
-      },
-    {% endif %}
+        "serf_lan": {{ consul_ports.serf_lan }},
+        "serf_wan": {{ consul_ports.serf_wan }},
+        "server": {{ consul_ports.server }},
+    },
 
     {## DNS ##}
     {% if consul_recursors | length > 0 %}

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -62,7 +62,7 @@
     "enable_syslog": {{ consul_syslog_enable | bool | to_json }},
     "enable_script_checks": {{ consul_enable_script_checks | bool | to_json }},
 
-    {# Encryption and TLS ##}
+    {## Encryption and TLS ##}
     "encrypt": "{{ consul_raw_key }}",
     {% if consul_tls_enable %}
         "ca_file": "{{ consul_tls_dir }}/{{ consul_tls_ca_crt }}",
@@ -73,20 +73,39 @@
         "verify_server_hostname": {{ consul_tls_verify_server_hostname | bool | to_json }},
     {% endif %}
 
+    {## ACLs ##}
+    {% if consul_acl_enable %}
+        "acl_ttl": "{{ consul_acl_ttl }}",
+        "acl_datacenter": "{{ consul_acl_datacenter }}",
+        "acl_down_policy": "{{ consul_acl_down_policy }}",
+        {% if consul_acl_token | trim != '' %}
+            "acl_token": "{{ consul_acl_token }}",
+        {% endif %}
+        {% if consul_acl_agent_token | trim != '' %}
+            "acl_agent_token": "{{ consul_acl_agent_token }}",
+        {% endif %}
+        {% if consul_acl_agent_master_token | trim != '' %}
+            "acl_agent_master_token": "{{ consul_acl_agent_master_token }}"
+        {% endif %}
+    {% endif %}
+
     {## LAN Join ##}
     "start_join": [
         {% for server in _consul_lan_servers %}
             "{{ hostvars[server]['consul_bind_address'] | ipwrap }}",
         {% endfor %} ],
 
-    {## Server/Client ##}
-    "server": {{ (item.config_version != 'client') | bool | to_json }},
-
     {## UI ##}
     "ui": {{ consul_ui | bool | to_json }},
 
-    {# Server Settings #}
+    {## Server/Client ##}
+    "server": {{ (item.config_version != 'client') | bool | to_json }},
 
+    {# Client Settings #}
+    {% if (item.config_version == 'client') %}
+    {% endif %}
+
+    {# Server Settings #}
     {% if (item.config_version == 'server') or (item.config_version == 'bootstrap') %}
 
         {## Bootstrap settings ##}
@@ -103,11 +122,16 @@
                 {% endfor %} ],
         {% endif %}
 
-        {## ACLs ##}
+        {## Server ACLs ##}
         {% if consul_acl_enable %}
-            "acl_datacenter": "{{ consul_acl_datacenter }}",
             "acl_default_policy": "{{ consul_acl_default_policy }}",
-            "acl_master_token": "{{ consul_acl_master_token }}"
+            "acl_master_token": "{{ consul_acl_master_token }}",
+            {% if consul_acl_replication_enable | trim != '' %}
+                "enable_acl_replication": {{ consul_acl_replication_enable | bool | to_json }},
+            {% endif %}
+            {% if consul_acl_replication_token | trim != '' %}
+                "acl_replication_token": "{{ consul_acl_replication_token }}",
+            {% endif %}
         {% endif %}
     {% endif %}
 }

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -22,7 +22,7 @@
         "dns": "{{ consul_addresses.dns }}",
         "http": "{{ consul_addresses.http }}",
         "https": "{{ consul_addresses.https }}",
-        {% if consul_version | version_compare('8.0', '<') %}
+        {% if consul_version | version_compare('0.8.0', '<') %}
             "rpc": "{{ consul_addresses.rpc }}",
         {% endif %}
     },
@@ -31,13 +31,16 @@
         "dns": {{ consul_ports.dns }},
         "http": {{ consul_ports.http }},
         "https": {{ consul_ports.https }},
-        {% if consul_version | version_compare('8.0', '<') %}
+        {% if consul_version | version_compare('0.8.0', '<') %}
             "rpc": {{ consul_ports.rpc}},
         {% endif %}
         "serf_lan": {{ consul_ports.serf_lan }},
         "serf_wan": {{ consul_ports.serf_wan }},
         "server": {{ consul_ports.server }},
     },
+
+    {## Raft protocol ##}
+    "raft_protocol": {{ consul_raft_protocol }},
 
     {## DNS ##}
     {% if consul_recursors | length > 0 %}

--- a/templates/dnsmasq-10-consul.j2
+++ b/templates/dnsmasq-10-consul.j2
@@ -1,9 +1,9 @@
 {# Enable forward lookups for the consul domain -#}
-server=/{{ consul_domain }}/{{ consul_dns_bind_address }}#{{ consul_ports['dns'] }}
+server=/{{ consul_domain }}/{{ consul_addresses.dns }}#{{ consul_ports.dns }}
 
 {# Reverse DNS lookups -#}
 {% for revserver in consul_dnsmasq_revservers -%}
-    rev-server={{ revserver }},{{ consul_dns_bind_address }}#{{ consul_ports['dns'] }}
+    rev-server={{ revserver }},{{ consul_addresses.dns }}#{{ consul_ports.dns }}
 {% endfor -%}
 
 {# Only accept DNS queries from hosts in the local subnet -#}


### PR DESCRIPTION
Fixes ACL settings and adds a few missing ones.

Adds missing address and port settings and prevents deprecation warnings for rpc settings on nodes using consul > 0.8.0. Not 100% all defaults make sense because the consul docs are a little vague on these and how they compare to each other.

It does have a few non backwards compatible changes to keep the defaults and config template cleaner.
(address and port settings mainly)