### PR TITLE
dnsmasq updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,12 @@ consul3.node.consul.  0 IN  A 10.1.42.230
 ;;
 ```
 
+### `consul_dnsmasq_consul_address`
+
+- Address used by dnsmasq to query consul
+- Default value: `consul_address.dns`
+- Defaults to 127.0.0.1 if consul's DNS is bound to all interfaces (eg `0.0.0.0`)
+
 ### `consul_dnsmasq_cache`
 
 - dnsmasq cache-size
@@ -759,6 +765,12 @@ consul3.node.consul.  0 IN  A 10.1.42.230
 
 - Only allow requests from local subnets
 - Default value: false
+
+### `consul_dnsmasq_listen_addresses`
+
+- Custom list of addresses to listen on.
+- Default value: *{}*
+
 
 ### iptables DNS Forwarding Support
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -150,6 +150,13 @@ consul_tls_verify_server_hostname: false
 
 ## DNS
 consul_dnsmasq_enable: "{{ lookup('env','CONSUL_DNSMASQ_ENABLE') | default(false, true) }}"
+consul_dnsmasq_consul_address: "\
+  {# Use localhost if DNS is listening on all interfaces #}\
+  {% if consul_addresses.dns == '0.0.0.0' %}\
+    127.0.0.1\
+  {% else %}\
+    {{ consul_addresses.dns }}\
+  {% endif %}"
 consul_dnsmasq_cache: -1
 consul_dnsmasq_servers:
   - 8.8.8.8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -165,4 +165,5 @@ consul_dnsmasq_revservers: {}
 consul_dnsmasq_no_poll: false
 consul_dnsmasq_no_resolv: false
 consul_dnsmasq_local_service: false
+consul_dnsmasq_listen_addresses: {}
 consul_iptables_enable: "{{ lookup('env','CONSUL_IPTABLES_ENABLE') | default(false, true) }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,9 +11,3 @@
   service:
     name: dnsmasq
     state: restarted
-
-- name: start dnsmasq
-  service:
-    name: dnsmasq
-    enabled: yes
-    state: started

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -26,6 +26,7 @@
   service:
     name: dnsmasq
     enabled: yes
+  tags: dnsmasq
 
 - name: Create Dnsmasq configuration directory
   file:

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -22,21 +22,10 @@
   when: ansible_os_family == "FreeBSD"
   tags: dnsmasq, installation
 
-- name: Stop Dnsmasq service
+- name: Enable dnsmasq service
   service:
     name: dnsmasq
-    state: stopped
-
-- name: Create Dnsmasq configuration
-  template:
-    src: dnsmasq-10-consul.j2
-    dest: /etc/dnsmasq.d/10-consul
-    owner: root
-    group: root
-    mode: 0644
-  notify: start dnsmasq
-  when: ansible_os_family == "Debian"
-  tags: dnsmasq
+    enabled: yes
 
 - name: Create Dnsmasq configuration directory
   file:
@@ -47,10 +36,22 @@
   when: ansible_os_family == "FreeBSD"
   tags: dnsmasq
 
+- name: Create Dnsmasq configuration
+  template:
+    src: dnsmasq-10-consul.j2
+    dest: /etc/dnsmasq.d/10-consul
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart dnsmasq
+  when: ansible_os_family == "Debian"
+  tags: dnsmasq
+
 - name: Create FreeBSD-specific configuration
   lineinfile:
     dest: /usr/local/etc/dnsmasq.conf
     line: 'conf-dir=/usr/local/etc/dnsmasq.d/,*.conf'
+  notify: restart dnsmasq
   when: ansible_os_family == "FreeBSD"
   tags: dnsmasq
 
@@ -61,6 +62,6 @@
     owner: root
     group: wheel
     mode: 0644
-  notify: start dnsmasq
+  notify: restart dnsmasq
   when: ansible_os_family == "FreeBSD"
   tags: dnsmasq

--- a/templates/dnsmasq-10-consul.j2
+++ b/templates/dnsmasq-10-consul.j2
@@ -1,9 +1,9 @@
 {# Enable forward lookups for the consul domain -#}
-server=/{{ consul_domain }}/{{ consul_addresses.dns }}#{{ consul_ports.dns }}
+server=/{{ consul_domain }}/{{ consul_dnsmasq_consul_address }}#{{ consul_ports.dns }}
 
 {# Reverse DNS lookups -#}
 {% for revserver in consul_dnsmasq_revservers -%}
-    rev-server={{ revserver }},{{ consul_addresses.dns }}#{{ consul_ports.dns }}
+    rev-server={{ revserver }},{{ consul_dnsmasq_consul_address }}#{{ consul_ports.dns }}
 {% endfor -%}
 
 {# Only accept DNS queries from hosts in the local subnet -#}

--- a/templates/dnsmasq-10-consul.j2
+++ b/templates/dnsmasq-10-consul.j2
@@ -26,6 +26,11 @@ server=/{{ consul_domain }}/{{ consul_dnsmasq_consul_address }}#{{ consul_ports.
     server={{ server }}
 {% endfor -%}
 
+{# Custom listen addresses -#}
+{% for address in consul_dnsmasq_listen_addresses -%}
+    listen-address={{ address }}
+{% endfor -%}
+
 {# Cache size -#}
 {% if consul_dnsmasq_cache > 0 -%}
     cache-size={{ consul_dnsmasq_cache }}


### PR DESCRIPTION
Fixes a little bug that prevented dnsmasq from getting the consul DNS data when consul binds to all interfaces (`0.0.0.0`). In this case, dnsmasq will now just query localhost.

Adds the dnsmasq `listen-address` option, only configured if provided.

Updates the dnsmasq service management to make sure it is enabled, and restarted if config is changed.