### PR TITLE
Allow post setup bootstrapping of ACL's

### DIFF
--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -131,7 +131,10 @@
         {## Server ACLs ##}
         {% if consul_acl_enable %}
             "acl_default_policy": "{{ consul_acl_default_policy }}",
-            "acl_master_token": "{{ consul_acl_master_token }}",
+            {% if consul_version | version_compare('0.9.1', '<') or
+                  consul_acl_master_token | trim != '' %}
+                "acl_master_token": "{{ consul_acl_master_token }}",
+            {% endif %}
             {% if consul_acl_replication_enable | trim != '' %}
                 "enable_acl_replication": {{ consul_acl_replication_enable | bool | to_json }},
             {% endif %}


### PR DESCRIPTION
For this to work, consul version must be `0.9.1` or above and
`acl_master_token` must not be set. So we only set the option if consul
version is lower then `0.9.1` or if the master token is not empty.