### PR TITLE
Fix types that should be lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ consul3.node.consul.  0 IN  A 10.1.42.230
 ### `consul_dnsmasq_revservers`
 
 - Reverse lookup subnets
-- Default value: *{}*
+- Default value: *[]*
 
 ### `consul_dnsmasq_no_poll`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -167,9 +167,9 @@ consul_dnsmasq_cache: -1
 consul_dnsmasq_servers:
   - 8.8.8.8
   - 8.8.4.4
-consul_dnsmasq_revservers: {}
+consul_dnsmasq_revservers: []
 consul_dnsmasq_no_poll: false
 consul_dnsmasq_no_resolv: false
 consul_dnsmasq_local_service: false
-consul_dnsmasq_listen_addresses: {}
+consul_dnsmasq_listen_addresses: []
 consul_iptables_enable: "{{ lookup('env','CONSUL_IPTABLES_ENABLE') | default(false, true) }}"


### PR DESCRIPTION
Not only in the doc, but also in the defaults.yml file

This is actually untested, and only looked sensible as the text spoke of lists...