### PR TITLE
Fix python3 compatibility for meta data

### DIFF
--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -10,7 +10,7 @@
     {% if consul_version | version_compare('0.7.3', '>=') and
           consul_node_meta | length > 0 %}
         "node_meta": {
-            {% for _meta_key, _meta_value in consul_node_meta.iteritems() %}
+            {% for _meta_key, _meta_value in consul_node_meta.items() %}
                 "{{ _meta_key }}": "{{ _meta_value }}",
             {% endfor %} },
     {% endif %}


### PR DESCRIPTION
`.iteritems` was removed in python 3 `.items` should be backwards compatible (although less efficient in python 2).