### PR TITLE
Fix idempotency for directories

### DIFF
--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -5,8 +5,8 @@
   file:
     dest: "{{ consul_tls_dir }}"
     state: directory
-    owner: root
-    group: root
+    owner: "{{ consul_user }}"
+    group: "{{ consul_group }}"
     mode: 0755
 
 - block:


### PR DESCRIPTION
The "Create SSL directory" task creates directories as `root:root`, which causes the "Create directories" (from dirs.yml) to always register as changed and thrash the two tasks. Setting ownership to the consul user from the getgo allows us to hit the beautiful `ok=17   changed=0    unreachable=0    failed=0` output on the second run.