### PR TITLE
make gossip encryption optional fixes #126

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -143,7 +143,7 @@ consul_acl_replication_enable: "{{ lookup('env','CONSUL_ACL_REPLICATION_ENABLE')
 consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') | default('', true) }}"
 
 ## gossip encryption
-consul_encrypt_enable: "{{ lookup('env','CONSUL_TLS_ENABLE') | default(true, true) }}"
+consul_encrypt_enable: "{{ lookup('env','CONSUL_ENCRYPT_ENABLE') | default(true, true) }}"
 
 ## TLS
 consul_tls_enable: "{{ lookup('env','CONSUL_TLS_ENABLE') | default(false, true) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,6 +142,9 @@ consul_acl_master_token_display: "{{ lookup('env','CONSUL_ACL_MASTER_TOKEN_DISPL
 consul_acl_replication_enable: "{{ lookup('env','CONSUL_ACL_REPLICATION_ENABLE') | default('',true) }}"
 consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') | default('', true) }}"
 
+## gossip encryption
+consul_encrypt_enable: "{{ lookup('env','CONSUL_TLS_ENABLE') | default(true, true) }}"
+
 ## TLS
 consul_tls_enable: "{{ lookup('env','CONSUL_TLS_ENABLE') | default(false, true) }}"
 consul_tls_src_files: "{{ lookup('env','CONSUL_TLS_SRC_FILES') | default(role_path+'/files', true) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,75 +79,78 @@
 
     # XXX: Individual gossip tasks are deprecated and need to be removed
     # - include: ../tasks/encrypt_gossip.yml
-
     - block:
-        - name: Check for gossip encryption key on previously boostrapped server
-          slurp:
-            src: "{{ consul_config_path }}/config.json"
-          register: consul_config_b64
-          ignore_errors: yes
+        - block:
+            - name: Check for gossip encryption key on previously boostrapped server
+              slurp:
+                src: "{{ consul_config_path }}/config.json"
+              register: consul_config_b64
+              ignore_errors: yes
 
-        - name: Deserialize existing configuration
-          set_fact:
-            consul_config: "{{ consul_config_b64.content | b64decode | from_json }}"
-          when: consul_config_b64.content is defined
+            - name: Deserialize existing configuration
+              set_fact:
+                consul_config: "{{ consul_config_b64.content | b64decode | from_json }}"
+              when: consul_config_b64.content is defined
 
-        - name: Save gossip encryption key from existing configuration
-          set_fact:
-            consul_raw_key: "{{ consul_config.encrypt }}"
-          when: consul_config is defined
+            - name: Save gossip encryption key from existing configuration
+              set_fact:
+                consul_raw_key: "{{ consul_config.encrypt }}"
+              when: consul_config is defined
 
-      no_log: true
-      when:
-        - consul_raw_key is not defined
-        - bootstrap_state.stat.exists | bool
-        - inventory_hostname in consul_servers
+          no_log: true
+          when:
+            - consul_raw_key is not defined
+            - bootstrap_state.stat.exists | bool
+            - inventory_hostname in consul_servers
 
-    # Key provided by extra vars or the above block
-    - name: Write gossip encryption key locally for use with new servers
-      copy:
-        content: "{{ consul_raw_key }}"
-        dest: '/tmp/consul_raw.key'
-      become: no
-      no_log: true
-      run_once: true
-      register: consul_local_key
-      delegate_to: localhost
-      when: consul_raw_key is defined
-
-    # Generate new key if none was found
-    - block:
-        - name: Generate gossip encryption key
-          shell: "PATH={{ consul_bin_path }}:$PATH consul keygen"
-          register: consul_keygen
-
-        - name: Write key locally to share with other nodes
+        # Key provided by extra vars or the above block
+        - name: Write gossip encryption key locally for use with new servers
           copy:
-            content: "{{ consul_keygen.stdout }}"
+            content: "{{ consul_raw_key }}"
             dest: '/tmp/consul_raw.key'
           become: no
+          no_log: true
+          run_once: true
+          register: consul_local_key
           delegate_to: localhost
+          when: consul_raw_key is defined
 
+        # Generate new key if none was found
+        - block:
+            - name: Generate gossip encryption key
+              shell: "PATH={{ consul_bin_path }}:$PATH consul keygen"
+              register: consul_keygen
+
+            - name: Write key locally to share with other nodes
+              copy:
+                content: "{{ consul_keygen.stdout }}"
+                dest: '/tmp/consul_raw.key'
+              become: no
+              delegate_to: localhost
+
+          no_log: true
+          run_once: true
+          when:
+            - not consul_local_key.changed
+            - not bootstrap_state.stat.exists | bool
+
+        - name: Read gossip encryption key for servers that require it
+          set_fact:
+            consul_raw_key: "{{ lookup('file', '/tmp/consul_raw.key') }}"
+          no_log: true
+          when:
+            - consul_raw_key is not defined
+
+        - name: Delete gossip encryption key file
+          file:
+            path: '/tmp/consul_raw.key'
+            state: absent
+          become: no
+          run_once: true
+          delegate_to: localhost
       no_log: true
-      run_once: true
       when:
-        - not consul_local_key.changed
-        - not bootstrap_state.stat.exists | bool
-
-    - name: Read gossip encryption key for servers that require it
-      set_fact:
-        consul_raw_key: "{{ lookup('file', '/tmp/consul_raw.key') }}"
-      no_log: true
-      when:
-        - consul_raw_key is not defined
-
-    - name: Delete gossip encryption key file
-      file:
-        path: '/tmp/consul_raw.key'
-        state: absent
-      become: no
-      run_once: true
-      delegate_to: localhost
+        - consul_encrypt_enable
 
     - name: Create Consul configuration
       include: config.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -317,74 +317,78 @@
         - not consul_binary_installed.stat.exists | bool
 
     - block:
-        - name: (Windows) Check for gossip encryption key on previously boostrapped server
-          slurp:
-            src: "{{ consul_config_path }}/config.json"
-          register: consul_config_b64
-          ignore_errors: yes
+        - block:
+            - name: (Windows) Check for gossip encryption key on previously boostrapped server
+              slurp:
+                src: "{{ consul_config_path }}/config.json"
+              register: consul_config_b64
+              ignore_errors: yes
 
-        - name: (Windows) Deserialize existing configuration
-          set_fact:
-            consul_config: "{{ consul_config_b64.content | b64decode | from_json }}"
-          when: consul_config_b64.content is defined
+            - name: (Windows) Deserialize existing configuration
+              set_fact:
+                consul_config: "{{ consul_config_b64.content | b64decode | from_json }}"
+              when: consul_config_b64.content is defined
 
-        - name: (Windows) Save gossip encryption key from existing configuration
-          set_fact:
-            consul_raw_key: "{{ consul_config.encrypt }}"
-          when: consul_config is defined
+            - name: (Windows) Save gossip encryption key from existing configuration
+              set_fact:
+                consul_raw_key: "{{ consul_config.encrypt }}"
+              when: consul_config is defined
 
-      no_log: true
-      when:
-        - consul_raw_key is not defined
-        - bootstrap_state.stat.exists | bool
-        - inventory_hostname in consul_servers
+          no_log: true
+          when:
+            - consul_raw_key is not defined
+            - bootstrap_state.stat.exists | bool
+            - inventory_hostname in consul_servers
 
-    # Key provided by extra vars or the above block
-    - name: (Windows) Write gossip encryption key locally for use with new servers
-      copy:
-        content: "{{ consul_raw_key }}"
-        dest: '/tmp/consul_raw.key'
-      become: no
-      no_log: true
-      run_once: true
-      register: consul_local_key
-      delegate_to: localhost
-      when: consul_raw_key is defined
-
-    # Generate new key if non was found
-    - block:
-
-        - name: (Windows) Generate gossip encryption key
-          win_shell: "{{consul_binary}} keygen"
-          register: consul_keygen
-
-        - name: (Windows) Write key locally to share with other nodes
+        # Key provided by extra vars or the above block
+        - name: (Windows) Write gossip encryption key locally for use with new servers
           copy:
-            content: "{{ consul_keygen.stdout }}"
+            content: "{{ consul_raw_key }}"
             dest: '/tmp/consul_raw.key'
           become: no
+          no_log: true
+          run_once: true
+          register: consul_local_key
           delegate_to: localhost
+          when: consul_raw_key is defined
 
+        # Generate new key if non was found
+        - block:
+
+            - name: (Windows) Generate gossip encryption key
+              win_shell: "{{consul_binary}} keygen"
+              register: consul_keygen
+
+            - name: (Windows) Write key locally to share with other nodes
+              copy:
+                content: "{{ consul_keygen.stdout }}"
+                dest: '/tmp/consul_raw.key'
+              become: no
+              delegate_to: localhost
+
+          no_log: true
+          run_once: true
+          when:
+            - not consul_local_key.changed
+            - not bootstrap_state.stat.exists | bool
+
+        - name: (Windows) Read gossip encryption key for servers that require it
+          set_fact:
+            consul_raw_key: "{{ lookup('file', '/tmp/consul_raw.key') }}"
+          no_log: true
+          when:
+            - consul_raw_key is not defined
+
+        - name: (Windows) Delete gossip encryption key file
+          file:
+            path: '/tmp/consul_raw.key'
+            state: absent
+          become: no
+          run_once: true
+          delegate_to: localhost
       no_log: true
-      run_once: true
       when:
-        - not consul_local_key.changed
-        - not bootstrap_state.stat.exists | bool
-
-    - name: (Windows) Read gossip encryption key for servers that require it
-      set_fact:
-        consul_raw_key: "{{ lookup('file', '/tmp/consul_raw.key') }}"
-      no_log: true
-      when:
-        - consul_raw_key is not defined
-
-    - name: (Windows) Delete gossip encryption key file
-      file:
-        path: '/tmp/consul_raw.key'
-        state: absent
-      become: no
-      run_once: true
-      delegate_to: localhost
+        - consul_encrypt_enable
 
     - name: (Windows) Create Consul configuration
       include: config_windows.yml

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -60,7 +60,9 @@
     "enable_script_checks": {{ consul_enable_script_checks | bool | to_json }},
 
     {## Encryption and TLS ##}
-    "encrypt": "{{ consul_raw_key }}",
+    {% if consul_encrypt_enable %}
+        "encrypt": "no key",
+    {% endif %}
     {% if consul_tls_enable %}
         "ca_file": "{{ consul_tls_dir }}/{{ consul_tls_ca_crt }}",
         "cert_file": "{{ consul_tls_dir }}/{{ consul_tls_server_crt }}",


### PR DESCRIPTION
I added a new variable `consul_encrypt_enable`.

The default value will not change anything, but if you set it to false it will skip all parts that are handling gossip encryption stuff.