### PR TITLE
Add armv6l to arch mapping

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ consul_architecture_map:
   # (but it's required for reasons)
   amd64: amd64
   x86_64: amd64
+  armv6l: arm
   armv7l: arm
   aarch64: arm64
   32-bit: "386"


### PR DESCRIPTION
This arch appears on *at least* Raspberry Pi Zero systems.