### PR TITLE
extra-args is being ignored because at wrong ident level

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Install netaddr dependency on controlling host as user
   pip:
     name: netaddr
-  extra_args: --user
+    extra_args: --user
   delegate_to: 127.0.0.1
   become: false
 


### PR DESCRIPTION
```
- pip:
    name: bottle
    extra_args: --user
```