### PR TITLE
Add consul autopilot configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,17 +532,17 @@ ports can be done using the `consul_ports_*` variables.
 ### `consul_disable_update_check`
 
 - Disable the consul update check?
-- Default vaule: *false*
+- Default value: *false*
 
 ### `consul_enable_script_checks`
 
 - Enable script based checks?
-- Default vaule: *false*
+- Default value: *false*
 
 ### `consul_raft_protocol`
 
 - Raft protocol to use.
-- Default vaule:
+- Default value:
 - `consul_version` <= `0.7.0`: *1*
 - `consul_version` > `0.7.0`: *3*
 
@@ -581,6 +581,69 @@ consul4.local consul_node_role=client
 ```
 
 > Note that this second form is the prefered one, because it is simpler.
+
+
+### `consul_autopilot_enable`
+
+Autopilot is a set of new features added in Consul 0.8 to allow for automatic operator-friendly management of Consul servers. It includes cleanup of dead servers, monitoring the state of the Raft cluster, and stable server introduction.
+
+https://www.consul.io/docs/guides/autopilot.html
+
+- Enable Autopilot config (will be written to bootsrapper node)
+  - Override with `CONSUL_AUTOPILOT_ENABLE` environment variable
+- Default value: *false*
+
+#### `consul_autopilot_cleanup_dead_Servers`
+
+Dead servers will periodically be cleaned up and removed from the Raft peer set, to prevent them from interfering with the quorum size and leader elections. This cleanup will also happen whenever a new server is successfully added to the cluster.
+
+- Enable Autopilot config (will be written to bootsrapper node)
+  - Override with `CONSUL_AUTOPILOT_CLEANUP_DEAD_SERVERS` environment variable
+- Default value: *false*
+
+#### `consul_autopilot_last_contact_threshold`
+
+Used in the serf health check to determine node health.
+
+- Sets the threshold for time since last contact
+  - Override with `CONSUL_AUTOPILOT_LAST_CONTACT_THRESHOLD` environment variable
+- Default value: '200ms'
+
+#### `consul_autopilot_max_trailing_logs`
+
+- Used in the serf health check to set a max-number of log entries nodes can trail the leader
+  - Override with `CONSUL_AUTOPILOT_MAX_TRAILING_LOGS` environment variable
+- Default value: 250
+
+
+#### `consul_autopilot_server_stabilization_time`
+
+- Time to allow a new node to stabilize
+  - Override with `CONSUL_AUTOPILOT_SERVER_STABILIZATION_TIME` environment variable
+- Default value: '10s'
+
+#### `consul_autopilot_redundancy_zone_tag`
+
+_Consul Enterprise Only (requires that CONSUL_ENTERPRISE is set to true)_
+
+  - Override with `CONSUL_AUTOPILOT_REDUNDANCY_ZONE_TAG` environment variable
+- Default value: 'az'
+
+#### `consul_autopilot_disable_upgrade_migration`
+
+_Consul Enterprise Only (requires that CONSUL_ENTERPRISE is set to true)_
+
+  - Override with `CONSUL_AUTOPILOT_DISABLE_UPGRADE_MIGRATION` environment variable
+- Default value: **false**
+
+#### `consul_autopilot_upgrade_version_tag`
+
+_Consul Enterprise Only (requires that CONSUL_ENTERPRISE is set to true)_
+
+  - Override with `CONSUL_AUTOPILOT_UPGRADE_VERSION_TAG` environment variable
+- Default value: ''
+
+
 
 #### Custom Configuration Section
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,6 +84,16 @@ consul_retry_interval_wan: "30s"
 consul_retry_max: 0
 consul_retry_max_wan: 0
 
+### Autopilot
+consul_autopilot_enable: "{{ lookup('env', 'CONSUL_AUTOPILOT_ENABLE') | default(false, true) }}"
+consul_autopilot_cleanup_dead_Servers: "{{ lookup('env', 'CONSUL_AUTOPILOT_CLEANUP_DEAD_SERVERS') | default(false, true) }}"
+consul_autopilot_last_contact_threshold: "{{ lookup('env', 'CONSUL_AUTOPILOT_LAST_CONTACT_THRESHOLD') | default('200ms', true) }}"
+consul_autopilot_max_trailing_logs: "{{ lookup('env', 'CONSUL_AUTOPILOT_MAX_TRAILING_LOGS') | default(250, true) }}"
+consul_autopilot_server_stabilization_time: "{{ lookup('env', 'CONSUL_AUTOPILOT_SERVER_STABILIZATION_TIME') | default('10s', true) }}"
+consul_autopilot_redundancy_zone_tag: "{{ lookup('env', 'CONSUL_AUTOPILOT_REDUNDANCY_ZONE_TAG') | default('az', true) }}"
+consul_autopilot_disable_upgrade_migration: "{{ lookup('env', 'CONSUL_AUTOPILOT_DISABLE_UPGRADE_MIGRATION') | default(false, true) }}"
+consul_autopilot_upgrade_version_tag: "{{ lookup('env', 'CONSUL_AUTOPILOT_UPGRADE_VERSION_TAG') | default('', true) }}"
+
 ### Addresses
 consul_bind_address: "\
   {% if ansible_system == 'FreeBSD' %}\
@@ -187,6 +197,8 @@ consul_dnsmasq_no_resolv: false
 consul_dnsmasq_local_service: false
 consul_dnsmasq_listen_addresses: []
 consul_iptables_enable: "{{ lookup('env','CONSUL_IPTABLES_ENABLE') | default(false, true) }}"
+
+consul_enterprise: "{{ lookup('env','CONSUL_ENTERPRISE') | default(false, true) }}"
 
 # Performance
 consul_performance:

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -112,15 +112,17 @@
 
         {## AutoPilot ##}
         {% if consul_autopilot_enable %}
-        "cleanup_dead_servers": {{ consul_autopilot_cleanup_dead_Servers | bool | to_json }},
-        "last_contact_threshold": "{{ consul_autopilot_last_contact_threshold }}",
-        "max_trailing_logs": {{ consul_autopilot_max_trailing_logs }},
-        "server_stabilization_time": "{{ consul_autopilot_server_stabilization_time }}",
-        {% if consul_enterprise %}
-        "redundancy_zone_tag":  "{{ consul_autopilot_redundancy_zone_tag }}",
-        "disable_upgrade_migration": {{ consul_autopilot_disable_upgrade_migration | bool | to_json }},
-        "upgrade_version_tag": "{{ consul_autopilot_upgrade_version_tag }}"
-        {% endif %}
+        "autopilot": {
+            "cleanup_dead_servers": {{ consul_autopilot_cleanup_dead_Servers | bool | to_json }},
+            "last_contact_threshold": "{{ consul_autopilot_last_contact_threshold }}",
+            "max_trailing_logs": {{ consul_autopilot_max_trailing_logs }},
+            "server_stabilization_time": "{{ consul_autopilot_server_stabilization_time }}",
+            {% if consul_enterprise %}
+            "redundancy_zone_tag":  "{{ consul_autopilot_redundancy_zone_tag }}",
+            "disable_upgrade_migration": {{ consul_autopilot_disable_upgrade_migration | bool | to_json }},
+            "upgrade_version_tag": "{{ consul_autopilot_upgrade_version_tag }}"
+            {% endif %}
+        },
         {% endif %}
 
     {% endif %}

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -116,7 +116,7 @@
             "cleanup_dead_servers": {{ consul_autopilot_cleanup_dead_Servers | bool | to_json }},
             "last_contact_threshold": "{{ consul_autopilot_last_contact_threshold }}",
             "max_trailing_logs": {{ consul_autopilot_max_trailing_logs }},
-            "server_stabilization_time": "{{ consul_autopilot_server_stabilization_time }}",
+            "server_stabilization_time": "{{ consul_autopilot_server_stabilization_time }}"{{ ',' if consul_enterprise else '' }}
             {% if consul_enterprise %}
             "redundancy_zone_tag":  "{{ consul_autopilot_redundancy_zone_tag }}",
             "disable_upgrade_migration": {{ consul_autopilot_disable_upgrade_migration | bool | to_json }},

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -109,6 +109,20 @@
     "bootstrap": {{ (item.config_version == 'bootstrap') | bool | to_json }},
     {% if consul_bootstrap_expect and not (item.config_version == 'bootstrap') %}
         "bootstrap_expect": {{ _consul_lan_servercount | int }},
+
+        {## AutoPilot ##}
+        {% if consul_autopilot_enable %}
+        "cleanup_dead_servers": {{ consul_autopilot_cleanup_dead_Servers | bool | to_json }},
+        "last_contact_threshold": "{{ consul_autopilot_last_contact_threshold }}",
+        "max_trailing_logs": {{ consul_autopilot_max_trailing_logs }},
+        "server_stabilization_time": "{{ consul_autopilot_server_stabilization_time }}",
+        {% if consul_enterprise %}
+        "redundancy_zone_tag":  "{{ consul_autopilot_redundancy_zone_tag }}",
+        "disable_upgrade_migration": {{ consul_autopilot_disable_upgrade_migration | bool | to_json }},
+        "upgrade_version_tag": "{{ consul_autopilot_upgrade_version_tag }}"
+        {% endif %}
+        {% endif %}
+
     {% endif %}
 
     {## WAN Join ##}


### PR DESCRIPTION
Work in progress for #150 autopilot (as I'm yet to run it through test)
I've also added an enterprise attribute as some of the properties are only available in the paid version and I was paranoid about them causing issues in the OSS version (not sure if consulignores or warns)