### PR TITLE
allow modify dns setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,17 @@ consul_node_meta:
     node_meta2: "metadata2"
 ```
 
+### `consul_dns_config`
+
+- Consul dns config (key-value)
+- Default value: *{}*
+- Example:
+```yaml
+consul_dns_config:
+    service_ttl: {"*": "5s", "web": "30s"}
+    node_ttl: "10s"
+```
+
 ### `consul_log_level`
 
 - Log level as defined in [log_level or -log-level](https://www.consul.io/docs/agent/options.html#_log_level)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,7 @@ consul_syslog_facility: "{{ lookup('env','CONSUL_SYSLOG_FACILITY') | default('lo
 consul_datacenter: "{{ lookup('env','CONSUL_DATACENTER') | default('dc1', true) }}"
 consul_domain: "{{ lookup('env','CONSUL_DOMAIN') | default('consul', true) }}"
 consul_node_meta: {}
+consul_dns_config: {}
 consul_iface: "\
   {% if ansible_os_family == 'Windows' %}\
     {{ lookup('env','CONSUL_IFACE') | default(ansible_interfaces[0].interface_name, true) }}\

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -10,6 +10,7 @@
     {% if consul_version | version_compare('0.7.3', '>=') and consul_node_meta | length > 0 %}
     "node_meta": {{ consul_node_meta | default({})| to_json }},
     {% endif %}
+    "dns_config": {{ consul_dns_config | default({})| to_json }},
     {# Performance Settings #}
     "performance": {{ consul_performance | to_json }},
 


### PR DESCRIPTION
hello,

with `dns_config`, consul allows [various dns configurations](https://www.consul.io/docs/agent/options.html#dns_config), like `time to live` for node and services.


