### PR TITLE
Potential security problem with consul directory permissions

### DIFF
--- a/tasks/dirs.yml
+++ b/tasks/dirs.yml
@@ -7,6 +7,7 @@
     state: directory
     owner: "{{ consul_user }}"
     group: "{{ consul_group}}"
+    mode: 0700
     recurse: yes
   with_items:
     - "{{ consul_config_path }}"


### PR DESCRIPTION
Consul directory permissions are world-readable, and may contain ACL tokens.

We could make this configurable, but I thought hard and couldn't come up with a reason to make it readable by other users or the default bin group.