### PR TITLE
Clean deprecation warning for version compare

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,7 @@ consul_ui: "{{ lookup('env', 'CONSUL_UI') | default(true, true) }}"
 consul_disable_update_check: no
 consul_enable_script_checks: no
 consul_raft_protocol: "\
-  {% if consul_version | version_compare('0.7.0', '<=') %}\
+  {% if consul_version is version_compare('0.7.0', '<=') %}\
     1\
   {% else %}\
     3\

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -13,28 +13,28 @@
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution in ['RedHat', 'CentOS']
-    - ansible_distribution_version | version_compare(6, '<')
+    - ansible_distribution_version is version_compare(6, '<')
 
 - name: Check Debian version
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "Debian"
-    - ansible_distribution_version | version_compare(8, '<')
+    - ansible_distribution_version is version_compare(8, '<')
 
 - name: Check FreeBSD version
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "FreeBSD"
-    - ansible_distribution_version | version_compare(10, '<')
+    - ansible_distribution_version is version_compare(10, '<')
 
 - name: Check Ubuntu version
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "Ubuntu"
-    - ansible_distribution_version | version_compare(13.04, '<')
+    - ansible_distribution_version is version_compare(13.04, '<')
 
 - name: Check specified ethernet interface
   fail:
@@ -49,7 +49,7 @@
   when:
     - consul_iptables_enable | bool
     - ansible_distribution in ['RedHat', 'CentOS']
-    - ansible_distribution_version | version_compare(6, '>=')
+    - ansible_distribution_version is version_compare(6, '>=')
 
 - name: Check for both Dnsmasq and iptables enabled
   fail:

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -7,7 +7,7 @@
     "node_name": "{{ consul_node_name }}",
     "datacenter": "{{ consul_datacenter }}",
     "domain": "{{ consul_domain }}",
-    {% if consul_version | version_compare('0.7.3', '>=') and consul_node_meta | length > 0 %}
+    {% if consul_version is version_compare('0.7.3', '>=') and consul_node_meta | length > 0 %}
     "node_meta": {{ consul_node_meta | default({})| to_json }},
     {% endif %}
     {# Performance Settings #}
@@ -19,7 +19,7 @@
     "advertise_addr_wan": "{{ consul_advertise_address_wan }}",
     "client_addr": "{{ consul_client_address }}",
     "addresses": {
-        {% if consul_version | version_compare('0.8.0', '<') %}
+        {% if consul_version is version_compare('0.8.0', '<') %}
             "rpc": "{{ consul_addresses.rpc }}",
         {% endif %}
         "dns": "{{ consul_addresses.dns }}",
@@ -29,7 +29,7 @@
     },
     {## Ports Used ##}
     "ports": {
-        {% if consul_version | version_compare('0.8.0', '<') %}
+        {% if consul_version is version_compare('0.8.0', '<') %}
         "rpc": {{ consul_ports.rpc}},
         {% endif %}
         "dns": {{ consul_ports.dns }},
@@ -125,7 +125,7 @@
 
     {## Server ACLs ##}
     {% if consul_acl_enable %}
-    {% if consul_version | version_compare('0.9.1', '<') or
+    {% if consul_version is version_compare('0.9.1', '<') or
                 consul_acl_master_token | trim != '' %}
     "acl_master_token": "{{ consul_acl_master_token }}",
     {% endif %}

--- a/tests/test_vars.yml
+++ b/tests/test_vars.yml
@@ -84,7 +84,7 @@ consul_ui: "{{ lookup('env', 'CONSUL_UI') | default(true, true) }}"
 consul_disable_update_check: no
 consul_enable_script_checks: no
 consul_raft_protocol: "\
-  {% if consul_version | version_compare('0.7.0', '<=') %}\
+  {% if consul_version is version_compare('0.7.0', '<=') %}\
     1\
   {% else %}\
     3\


### PR DESCRIPTION
error :
[DEPRECATION WARNING]: Using tests as filters is deprecated.
Instead of using `result|version_compare` instead use `result is version_compare`.
This feature will be removed in version 2.9.