### PR TITLE
Assert if consul_group_name isn't included in groups

### DIFF
--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -65,6 +65,11 @@
     - consul_iptables_enable | bool
     - consul_recursors | length == 0
 
+- name: Check consul_group_name is included in groups
+  fail:
+    msg: "consul_group_name must be included in groups."
+  when: consul_group_name not in groups
+
 - name: Fail if more than one bootstrap server is defined
   fail:
     msg: "You can not define more than one bootstrap server."


### PR DESCRIPTION
If consul_group_name isn't included in groups,
the following error occurs.

```
TASK [brianshumate.consul : Fail if more than one bootstrap server is defined] ************************************************************
fatal: [server-1]: FAILED! => {"msg": "The conditional check '_consul_bootstrap_servers | length > 1' failed. The error was: error while evaluating conditional (_consul_bootstrap_servers | length > 1): 'dict object' has no attribute u'consul_instances'\n\nThe error appears to have been in '/Users/shunsuke/repos/src/github.com/shunsuke/ansible-playbook-consul/_roles/brianshumate.consul/tasks/asserts.yml': line 76, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  when: consul_group_name in groups\n- name: Fail if more than one bootstrap server is defined\n  ^ here\n"}
```

It took some time for me to understand why the error has occurred.