### PR TITLE
Fix consul_configd_path's default value at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ the variables are named and described below:
 ### `consul_configd_path`
 
 - Additional configuration directory
-- Default Linux value: `/etc/consul.d`
+- Default Linux value: `{{ consul_config_path }}/consul.d`
 - Default Windows value: `C:\ProgramData\consul\config.d`
 
 ### `consul_data_path`


### PR DESCRIPTION
If `consul_config_path` is default value (`/etc/consul`),
`consul_configd_path` is not `/etc/consul.d` but `/etc/consul/consul.d` by default.