### PR TITLE
Add support for environment variables.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,6 +83,8 @@ consul_retry_interval: "30s"
 consul_retry_interval_wan: "30s"
 consul_retry_max: 0
 consul_retry_max_wan: 0
+consul_env_vars:
+  - "CONSUL_UI_BETA=false"
 
 ### Autopilot
 consul_autopilot_enable: "{{ lookup('env', 'CONSUL_AUTOPILOT_ENABLE') | default(false, true) }}"

--- a/templates/consul_systemd.service.j2
+++ b/templates/consul_systemd.service.j2
@@ -29,6 +29,9 @@ KillMode=process
 KillSignal=SIGTERM
 Restart=on-failure
 RestartSec=42s
+{% for var in consul_env_vars %}
+Environment={{ var }}
+{% endfor %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hashicorp recently added the option to run an updated UI beta in Consul 1.1.0.

https://www.consul.io/intro/getting-started/ui.html#how-to-use-the-new-ui

This needs to be enabled via setting an environment variable, which this playbook had no support for, so I added it anyway. I considered adding a "consul_beta_ui" var, but because this is likely a short lived configuration, I thought it was better to keep it generic.

Thoughts?