### PR TITLE
Fixed usage of filters as tests (deprecated since 2.5)

### DIFF
--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -65,7 +65,7 @@
     group: "{{ consul_group }}"
     mode: 0755
   register: consul_install
-  when: consul_download | changed
+  when: consul_download is changed
   tags: installation
 
 - name: Daemon reload systemd in case the binaries upgraded
@@ -75,7 +75,7 @@
   when:
     - ansible_service_mgr == "systemd"
     - consul_install_upgrade
-    - consul_install | changed
+    - consul_install is changed
 
 - name: Cleanup
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -273,7 +273,7 @@
         wait_for:
           delay: 15
           path: "{{ consul_addresses.http | replace('unix://', '', 1) }}"
-        when: consul_addresses.http | match("unix://*")
+        when: consul_addresses.http is match("unix://*")
 
       - name: Create bootstrapped state file
         file:


### PR DESCRIPTION
Corrected the usage of filters as tests (i.e. `| changed` ⇒ `is changed`) which generates a warning as of Ansible 2.6 (has been deprecated in **2.5** and is scheduled to be removed in **2.9**).

https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#test-syntax