### PR TITLE
Added handler to reload configuration on Linux

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,6 +7,9 @@
 - name: start consul
   import_tasks: start_consul.yml
 
+- name: reload consul configuration
+  import_tasks: reload_consul_conf.yml
+
 - name: restart dnsmasq
   service:
     name: dnsmasq

--- a/handlers/reload_consul_conf.yml
+++ b/handlers/reload_consul_conf.yml
@@ -1,0 +1,7 @@
+---
+# Use SIGHUP to reload most configurations as per https://www.consul.io/docs/agent/options.html
+# Cannot use `consul reload` because it requires the HTTP API to be bound to a non-loopback interface
+
+- name: reload consul configuration on linux
+  command: "pkill --pidfile '{{ consul_run_path }}/consul.pid' --signal SIGHUP"
+  when: ansible_os_family != "Windows"


### PR DESCRIPTION
As per https://www.consul.io/docs/agent/options.html, the handler sends the **SIGHUP** signal using `pkill`, which is assumed to be available by default on all Linux distributions supported by the role.

`consul reload` cannot be reliably used because it requires the HTTP API to be bound to a non-loopback interface.

I cannot provide a Windows implementation.