### PR TITLE
fix: generate `consul_acl_master_token` when not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ ports can be done using the `consul_ports_*` variables.
 
 - ACL master token
   - Override with `CONSUL_ACL_MASTER_TOKEN` environment variable
-- Default value: *SN4K3OILSN4K3OILSN4K3OILSN4K3OIL*
+- Default value: *random uuid token*
 
 ### `consul_acl_master_token_display`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -158,7 +158,6 @@ consul_acl_agent_master_token: "{{ lookup('env','CONSUL_ACL_AGENT_MASTER_TOKEN')
 
 ### Server ACL settings ###
 consul_acl_default_policy: "{{ lookup('env','CONSUL_ACL_DEFAULT_POLICY') | default('allow', true) }}"
-consul_acl_master_token: "{{ lookup('env','CONSUL_ACL_MASTER_TOKEN') | default('42424242-4242-4242-4242-424242424242', true) }}"
 consul_acl_master_token_display: "{{ lookup('env','CONSUL_ACL_MASTER_TOKEN_DISPLAY') | default(false, true) }}"
 consul_acl_replication_enable: "{{ lookup('env','CONSUL_ACL_REPLICATION_ENABLE') | default('',true) }}"
 consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') | default('', true) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -164,12 +164,12 @@
       when:
         - consul_encrypt_enable
 
-    - name: Create Consul configuration
-      import_tasks: config.yml
-
     - name: Create ACL configuration
       include_tasks: acl.yml
       when: consul_acl_enable | bool
+
+    - name: Create Consul configuration
+      import_tasks: config.yml
 
     - name: Create TLS configuration
       include_tasks: tls.yml


### PR DESCRIPTION
Hi!

The `acl.yml` task was never used to generate `consul_acl_master_token` as the variable was present in default variables. 

Removing the variable will generate a new random `uuid` and set it as `consul_acl_master_token`. 

Because of the dependency with the configuration role, it is necessary to launch acl role before the configuration one. 