### PR TITLE
Fix apk cache

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -62,7 +62,7 @@
     module: apk
     update_cache: yes
   run_once: true
-  when: ansible_distribution == "Alpine"
+  when: lookup('file','/etc/alpine-release')
 
 - name: Install unzip package
   local_action:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -57,6 +57,13 @@
   tags: installation
   when: not consul_package.stat.exists | bool
 
+- name: Update alpine package manager (apk)
+  local_action:
+    module: apk
+    update_cache: yes
+  run_once: true
+  when: ansible_distribution == "Alpine"
+
 - name: Install unzip package
   local_action:
     module: package


### PR DESCRIPTION
fixing issue #189 when ansible run on an alpine machine couldn't install unzip because the apk cache wasn't populated nor refreshed