### PR TITLE
Fix windows sha256 read

### DIFF
--- a/tasks/install_windows.yml
+++ b/tasks/install_windows.yml
@@ -28,6 +28,8 @@
 
 - name: Read Consul package checksum
   win_shell: "findstr {{ consul_pkg }} /tmp/consul/consul_{{ consul_version }}_SHA256SUMS"
+  args:
+    chdir: /tmp/consul
   register: consul_pkg_checksum
   tags: installation
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -445,10 +445,8 @@
           stderr_file: "{{ consul_log_path }}/consul-nssm-error.log"
 
       - name: (Windows) Check Consul HTTP API
-        local_action:
-          module: wait_for
+        win_wait_for:
           delay: 5
-          host: "{{inventory_hostname_short}}"
           port: 8500
 
       - name: (Windows) Create bootstrapped state file


### PR DESCRIPTION
When current directory is not set to /tmp/consul, findstr cannot open downloaded file with sha256 sums, despite absolute path is mentioned in command.