### PR TITLE
Fix undefined is_virtualenv condition

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
       delegate_to: 127.0.0.1
       become: false
       run_once: true
-      when: is_virtualenv is not defined
+      when: is_virtualenv == '' or is_virtualenv == None
 
     - name: Install netaddr dependency on controlling host (virtualenv)
       pip:


### PR DESCRIPTION
As is_virtualenv is part of the defaults variables it is always defined.
Instead it should be checked against empty string or None.

Fixes #161