### PR TITLE
Update readme, note -l is incompatible with this role

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ definitely known to work with the following specific software versions:
 * Ubuntu: 16.04
 * Windows: Server 2012 R2
 
+**Note:** Do not use the ansible option `-l` to limit the hosts, as
+this will break populating the variables which are required to be
+populated for your play to work. If you do use `-l' you  may encounter
+'Undefined is not JSON serializable' errors in the template.
+
 ## Role Variables
 
 The role uses variables defined in these three sources:


### PR DESCRIPTION
Hello,

I just spent an embarrassing amount of time troubleshooting something that turned out to be stupidly simple and this pull request is to add a note to the README to help those who follow me avoid the same mistake I made.

This ansible role isn't compatible with the -l ansible option to limit the hosts that you're deploying to, or at least because of the advanced macros/variables in this role the use of that option can have unexpected consequences. 

I've spent the past day or two chasing down an 'Undefined is not JSON serializable' error, which turned out to be resolved by not limiting the scope of my ansible deploy to just the agents that I'm trying to deploy to because it was preventing ansible from gathering facts on my consul servers, meaning some variables didn't populate, which was the source of the error.

I had 4 consul servers in region A, 4 consul servers in region B, and 1 consul agent (so far) in region B. The agents are in a separate inventory group from the consul servers in region B. I was trying to deploy the ansible to the agents only in region B when I hit this problem. In hindsight it's obvious what the problem is, but when your caught in the weeds a note like the one I've added could really help people out I think. 

Thanks for your time,
Jeff