### PR TITLE
Ensure idempotent folder permissions

### DIFF
--- a/tasks/dirs.yml
+++ b/tasks/dirs.yml
@@ -8,7 +8,6 @@
     owner: "{{ consul_user }}"
     group: "{{ consul_group}}"
     mode: 0700
-    recurse: true
   with_items:
     - "{{ consul_config_path }}"
     - "{{ consul_configd_path }}"
@@ -22,7 +21,6 @@
     state: directory
     owner: "{{ syslog_user }}"
     group: "{{ syslog_group }}"
-    recurse: true
   with_items:
     - "{{ consul_log_path }}"
   when:


### PR DESCRIPTION
Files and folders created under Consul directories get their permissions
from the umask which is unlikely to be 0700. As a result, each run
changes permissions and report changes. If created files must have specific
permissions, a specific umask should be created for the Consul user.
Moreover, consul_tls_dir is created with 0755 permissions, also leading to
non idempotent runs.
Removing recurse option solve this.