### PR TITLE
feat: let user specify systemd restart time

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ consul_manage_user: yes
 consul_user: "consul"
 consul_manage_group: no
 consul_group: "bin"
+consul_systemd_restart_sec: 42
 
 ### Log user, group, facility
 syslog_user: "{{ lookup('env','SYSLOG_USER') | default('root', true) }}"

--- a/templates/consul_systemd.service.j2
+++ b/templates/consul_systemd.service.j2
@@ -28,7 +28,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 KillSignal=SIGTERM
 Restart=on-failure
-RestartSec=42s
+RestartSec={{ consul_systemd_restart_sec }}s
 {% for var in consul_env_vars %}
 Environment={{ var }}
 {% endfor %}


### PR DESCRIPTION
As a user, I want to manage with precision the way consul `systemd` unit works. 
This PR lets the user specify the duration applied to the Consul `systemd` unit in case of failure before trying to restart it. 

A default value is set in order to keep the previous behaviour of the role. 
