### PR TITLE
Added default variables & config entries for gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ consul_node_meta:
     http: "{{ consul_addresses_http | default(consul_client_address, true) }}"
     https: "{{ consul_addresses_https | default(consul_client_address, true) }}"
     rpc: "{{ consul_addresses_rpc | default(consul_client_address, true) }}"
+    grpc: "{{ consul_addresses_grpc | default(consul_client_address, true) }}"
   ```
 
 ### `consul_ports`
@@ -318,6 +319,7 @@ consul_node_meta:
   - http - The HTTP API, -1 to disable. Default 8500.
   - https - The HTTPS API, -1 to disable. Default -1 (disabled).
   - rpc - The CLI RPC endpoint. Default 8400. This is deprecated in Consul 0.8 and later.
+  - grpc - The gRPC endpoint, -1 to disable. Default -1 (disabled).
   - serf_lan - The Serf LAN port. Default 8301.
   - serf_wan - The Serf WAN port. Default 8302.
   - server - Server RPC address. Default 8300.
@@ -334,6 +336,7 @@ For example, to enable the consul HTTPS API it is possible to set the variable a
     serf_lan: "{{ consul_ports_serf_lan | default('8301', true) }}"
     serf_wan: "{{ consul_ports_serf_wan | default('8302', true) }}"
     server: "{{ consul_ports_server | default('8300', true) }}"
+    grpc: "{{ consul_ports_grpc | default('-1', true) }}"
 ```
 
 Notice that the dict object has to use precisely the names stated in the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -119,6 +119,7 @@ consul_addresses:
   http: "{{ consul_addresses_http | default(consul_client_address, true) }}"
   https: "{{ consul_addresses_https | default(consul_client_address, true) }}"
   rpc: "{{ consul_addresses_rpc | default(consul_client_address, true) }}"
+  grpc: "{{ consul_addresses_grpc | default(consul_client_address, true) }}"
 
 ### Ports
 consul_ports:
@@ -129,6 +130,7 @@ consul_ports:
   serf_lan: "{{ consul_ports_serf_lan | default('8301', true) }}"
   serf_wan: "{{ consul_ports_serf_wan | default('8302', true) }}"
   server: "{{ consul_ports_server | default('8300', true) }}"
+  grpc: "{{ consul_ports_grpc | default('-1', true) }}"
 
 ### Servers
 consul_group_name: "{{ lookup('env','CONSUL_GROUP_NAME') | default('consul_instances', true) }}"

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -24,8 +24,8 @@
         {% endif %}
         "dns": "{{ consul_addresses.dns }}",
         "http": "{{ consul_addresses.http }}",
-        "https": "{{ consul_addresses.https }}"
-
+        "https": "{{ consul_addresses.https }}",
+        "grpc": "{{ consul_addresses.grpc }}"
     },
     {## Ports Used ##}
     "ports": {
@@ -37,7 +37,8 @@
         "https": {{ consul_ports.https }},
         "serf_lan": {{ consul_ports.serf_lan }},
         "serf_wan": {{ consul_ports.serf_wan }},
-        "server": {{ consul_ports.server }}
+        "server": {{ consul_ports.server }},
+        "grpc": {{ consul_ports.grpc }}
     },
 
     {## Raft protocol ##}


### PR DESCRIPTION
gRPC is turned off by default, duplicating standard consul behavior.
gRPC is used by consul-envoy setup.