### PR TITLE
Fix consul restart handler reference

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -221,7 +221,7 @@
         group: root
         mode: 0644
       register: systemd_unit
-      notify: restart consul on linux
+      notify: restart consul on Linux
       when:
         - ansible_service_mgr == "systemd"
         - not ansible_os_family == "FreeBSD"


### PR DESCRIPTION
Ansible's handler references (sadly) are case sensitive. This fixes a small bug related to that; trying to restart consul on Linux hosts.