### PR TITLE
Ensure retrieval of existing consul cluster key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,13 +114,13 @@
             - inventory_hostname in consul_servers
 
         # Key provided by extra vars or the above block
+        # Searches all hosts for a retrieved encryption key
         - name: Write gossip encryption key locally for use with new servers
           copy:
             content: "{{ consul_raw_key }}"
             dest: '/tmp/consul_raw.key'
           become: false
           no_log: true
-          run_once: true
           register: consul_local_key
           delegate_to: localhost
           changed_when: false


### PR DESCRIPTION
Suppose we have a cluster consisting of three consul hosts. The first host has died and has to be newly provisioned.

Setting `run_once: yes` here will run this task only against the facts of that first new host. But that host does not have the encryption key in its config, since it is not configured yet. Therefore, this task will not write anything to the local file system, and the provisioning will silently fail.

Running this task (while delegated to localhost) against all hosts will ensure the `consul_raw.key` will be written to the local file system at least once.