### PR TITLE
Add disable_keyring_file configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,11 @@ ports can be done using the `consul_ports_*` variables.
 - Enable Gossip Encryption
 - Default value: `true`
 
+## `consul_disable_keyring_file`
+
+- If set, the keyring will not be persisted to a file. Any installed keys will be lost on shutdown, and only the given -encrypt key will be available on startup.
+- Default value: `false`
+
 ## `consul_raw_key`
 
 - Set the encryption key; should be the same across a cluster. If not present the key will be generated & retrieved from the bootstrapped server.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -168,6 +168,7 @@ consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') |
 
 ## gossip encryption
 consul_encrypt_enable: "{{ lookup('env','CONSUL_ENCRYPT_ENABLE') | default(true, true) }}"
+consul_disable_keyring_file: "{{ lookup('env','CONSUL_DISABLE_KEYRING_FILE') | default(false, true) }}"
 
 ## TLS
 consul_tls_enable: "{{ lookup('env','CONSUL_TLS_ENABLE') | default(false, true) }}"

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -61,6 +61,9 @@
     {% if consul_encrypt_enable %}
     "encrypt": "{{ consul_raw_key }}",
     {% endif %}
+    {% if consul_disable_keyring_file %}
+    "disable_keyring_file": true,
+    {% endif %}
     {% if consul_tls_enable %}
     "ca_file": "{{ consul_tls_dir }}/{{ consul_tls_ca_crt }}",
     "cert_file": "{{ consul_tls_dir }}/{{ consul_tls_server_crt }}",

--- a/tests/test_vars.yml
+++ b/tests/test_vars.yml
@@ -164,6 +164,7 @@ consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') |
 
 ## gossip encryption
 consul_encrypt_enable: "{{ lookup('env','CONSUL_ENCRYPT_ENABLE') | default(true, true) }}"
+consul_disable_keyring_file: "{{ lookup('env','CONSUL_DISABLE_KEYRING_FILE') | default(false, true) }}"
 
 ## TLS
 consul_tls_enable: "{{ lookup('env','CONSUL_TLS_ENABLE') | default(false, true) }}"


### PR DESCRIPTION
Adds the `disable_keyring_file` consul option.

I preferred to omit the line in the configuration file if set to false, rather than including it with a false value, so users will not see this change in their configuration, if they don't need to set the flag.

@brianshumate if you prefer instead to always have the option with the currently configured value in the config file, I can change that.