### PR TITLE
allow for snapshot agent installation and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,27 @@ _Consul Enterprise Only (requires that CONSUL_ENTERPRISE is set to true)_
   - Override with `CONSUL_AUTOPILOT_UPGRADE_VERSION_TAG` environment variable
 - Default value: ''
 
+## Consul Snapshot Agent
+
+_Consul snapshot agent takes backup snaps on a set interval and stores them. Must have enterprise_
+
+### `consul_snapshot`
+
+- Bool, true will setup and start snapshot agent (enterprise only)
+- Default value: false
+
+### `consul_snapshot_storage`
+
+- Location snapshots will be stored. NOTE: path must end in snaps
+- Default value: `{{ consul_config_path }}/snaps`
+
+### `consul_snapshot_interval`
+
+- Default value: `1h`
+
+### `consul_snapshot_retain`
+
+- Default value: `30`
 
 
 #### Custom Configuration Section

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -213,3 +213,10 @@ consul_performance:
   raft_multiplier: 1
   leave_drain_time: 5s
   rpc_hold_timeout: 7s
+
+# Snapshot
+consul_snapshot: false
+consul_snapshot_storage: "{{ consul_config_path }}/snaps"
+consul_snapshot_interval: 1h
+consul_snapshot_retain: 30
+consul_snapshot_stale: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -20,3 +20,9 @@
 
 - name: restart syslog-ng
   import_tasks: restart_syslogng.yml
+
+- name: restart syslog-ng
+  import_tasks: restart_syslogng.yml
+
+- name: start snapshot
+  import_tasks: start_snapshot.yml

--- a/handlers/start_snapshot.yml
+++ b/handlers/start_snapshot.yml
@@ -1,0 +1,7 @@
+---
+- name: start consul snapshot on linux
+  service:
+    name: consul_snapshot
+    state: started
+    enabled: true
+  when: ansible_os_family != "Windows"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -253,6 +253,14 @@
         - smfmanifest is changed
         - ansible_os_family == "Solaris"
 
+    - name: Enable Consul Snapshots on servers
+      include_tasks: snapshot.yml
+      when:
+        - ansible_service_mgr == "systemd"
+        - not ansible_os_family == "FreeBSD"
+        - not ansible_os_family == "Solaris"
+        - consul_snapshot | bool
+
     - block:
 
       - name: Start Consul

--- a/tasks/snapshot.yml
+++ b/tasks/snapshot.yml
@@ -1,0 +1,51 @@
+---
+# template: consul_snapshot.service
+# template: consul_snapshot.config /etc/consul/ set snaps to {{ snap storage location }}
+# create snaps folder
+# handler: start / enable service
+# add entry to tasks/main.yml
+# update readme
+# update defaults/main.yml
+# update my vars file
+
+- name: Create snapshot systemd script
+  template:
+    src: consul_systemd_snapshot.service.j2
+    dest: /lib/systemd/system/consul_snapshot.service
+    owner: root
+    group: root
+    mode: 0644
+  register: systemd_unit
+  notify: start snapshot
+  when:
+    - ansible_service_mgr == "systemd"
+    - not ansible_os_family == "FreeBSD"
+    - not ansible_os_family == "Solaris"
+    - consul_snapshot | bool
+
+- name: Create snapshot systemd script
+  template:
+    src: consul_snapshot.json.j2
+    dest: "{{ consul_config_path }}/consul_snapshot.json"
+    owner: "{{ consul_user }}"
+    group: "{{ consul_group }}"
+    mode: 0644
+  notify: start snapshot
+  when:
+    - ansible_service_mgr == "systemd"
+    - not ansible_os_family == "FreeBSD"
+    - not ansible_os_family == "Solaris"
+    - consul_snapshot | bool
+
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+  when: systemd_unit | changed
+
+- name: Create snaps storage folder
+  file:
+    state: directory
+    path: "{{ consul_snapshot_storage }}"
+    owner: "{{ consul_user }}"
+    group: "{{ consul_group }}"
+    mode: 0744

--- a/templates/consul_snapshot.json.j2
+++ b/templates/consul_snapshot.json.j2
@@ -1,0 +1,27 @@
+{
+"snapshot_agent": {
+    "http_addr": "{{ consul_client_address }}:{% if consul_tls_enable %}{{ consul_ports.https }}{% else %}{{ consul_ports.http }}{%endif%}",
+    {%- if consul_tls_enable -%}
+    "ca_file": "{{ consul_tls_dir }}/{{ consul_tls_ca_crt }}",
+    "cert_file": "{{ consul_tls_dir }}/{{ consul_tls_server_crt }}",
+    "key_file": "{{ consul_tls_dir }}/{{ consul_server_key }}",
+    {%- endif -%}
+        "log": {
+            "level": "INFO",
+            "enable_syslog": true,
+            "syslog_facility": "LOCAL0"
+        },
+        "snapshot": {
+            "interval": "{{ consul_snapshot_interval }}",
+            "retain": {{ consul_snapshot_retain }},
+            "stale": false,
+            "service": "consul_snapshot",
+            "deregister_after": "72h",
+            "lock_key": "consul_snapshot/lock",
+            "max_failures": 3
+        },
+        "local_storage": {
+            "path": "{{ consul_snapshot_storage }}"
+        }
+}
+}

--- a/templates/consul_systemd_snapshot.service.j2
+++ b/templates/consul_systemd_snapshot.service.j2
@@ -1,0 +1,33 @@
+### BEGIN INIT INFO
+# Provides: consul
+# Required-Start: $local_fs $remote_fs
+# Required-Stop: $local_fs $remote_fs
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: Consul snapshot agent
+# Description: Consul service snapshot agent
+### END INIT INFO
+
+[Unit]
+Description=Consul snapshot agent
+Requires=network-online.target
+Requisite=consul.service
+After=network-online.target
+
+[Service]
+User={{ consul_user }}
+Group={{ consul_group }}
+PIDFile={{ consul_run_path }}/consul_snapshot.pid
+PermissionsStartOnly=true
+ExecStart={{ consul_bin_path }}/consul snapshot agent \
+-config-file={{ consul_config_path }}/consul_snapshot.json
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+Restart=on-failure
+RestartSec=42s
+{% for var in consul_env_vars %}
+Environment={{ var }}
+{% endfor %}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
to have this playbook enable the consul snapshot agent, set `consul_snapshot` to true and other configurations to your need
such as snapshot dir location
snapshot interval
retention policy
etc

tested and works with TLS enabled and disabled
