### PR TITLE
[BUG #228] Delegate Consul datacenter DNS domain to Consul.

### DIFF
--- a/templates/dnsmasq-10-consul.j2
+++ b/templates/dnsmasq-10-consul.j2
@@ -1,5 +1,5 @@
 {# Enable forward lookups for the consul domain -#}
-server=/{{ consul_domain }}/{{ consul_dnsmasq_consul_address }}#{{ consul_ports.dns }}
+server=/{{ consul_datacenter }}.{{ consul_domain }}/{{ consul_dnsmasq_consul_address }}#{{ consul_ports.dns }}
 
 {# Reverse DNS lookups -#}
 {% for revserver in consul_dnsmasq_revservers -%}


### PR DESCRIPTION
The `dnsmasq` template used to generate `dnsmasq` configuration delegates `{{consul_domain}}` to Consul.

In environments where there are multiple clusters, `dnsmasq` should delegate `{{consul_datacenter}}.{{consul_domain}}`. This way DNS queries to Consul for other datacenters will be routed to upstream DNS servers (which should be configured to support federation).