### PR TITLE
Allow dnsmasq to bind to specific interfaces.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -188,6 +188,7 @@ consul_tls_files_remote_src: false
 
 ## DNS
 consul_dnsmasq_enable: "{{ lookup('env','CONSUL_DNSMASQ_ENABLE') | default(false, true) }}"
+consul_dnsmasq_bind_interfaces: false
 consul_dnsmasq_consul_address: "\
   {# Use localhost if DNS is listening on all interfaces #}\
   {% if consul_addresses.dns == '0.0.0.0' %}\

--- a/templates/dnsmasq-10-consul.j2
+++ b/templates/dnsmasq-10-consul.j2
@@ -1,6 +1,11 @@
 {# Enable forward lookups for the consul domain -#}
 server=/{{ consul_domain }}/{{ consul_dnsmasq_consul_address }}#{{ consul_ports.dns }}
 
+{# Only bind to specific interfaces -#}
+{% if consul_dnsmasq_bind_interfaces -%}
+bind-interfaces
+{% endif -%}
+
 {# Reverse DNS lookups -#}
 {% for revserver in consul_dnsmasq_revservers -%}
     rev-server={{ revserver }},{{ consul_dnsmasq_consul_address }}#{{ consul_ports.dns }}


### PR DESCRIPTION
Enabling this option via `consul_dnsmasq_bind_interfaces` prevents dnsmasq from binding by default 0.0.0.0, but instead instructs it to bind to the specific network interfaces that correspond to the `listen-address` option.
