### PR TITLE
Fix systemd configuration task handler notification

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -230,7 +230,7 @@
         group: root
         mode: 0644
       register: systemd_unit
-      notify: restart consul on Linux
+      notify: restart consul
       when:
         - ansible_service_mgr == "systemd"
         - not ansible_os_family == "FreeBSD"


### PR DESCRIPTION
By calling 'restart consul on Linux' instead of 'restart consul' the
Consul server is restarted twice if any other task notifies
'restart consul' as both get executed.