### PR TITLE
Remove token generation/retrieval on clients

### DIFF
--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -14,24 +14,30 @@
   when:
     - bootstrap_state.stat.exists | bool
     - (consul_acl_master_token is not defined or consul_acl_master_token == '')
+    - consul_node_role == 'server'
 
 - block:
   - name: Generate ACL master token
     command: "echo {{ ansible_date_time.iso8601_micro | to_uuid }}"
     register: consul_acl_master_token_keygen
     run_once: true
+
   - name: Save ACL master token
     set_fact:
       consul_acl_master_token: "{{ consul_acl_master_token_keygen.stdout }}"
+
   when:
     - (consul_acl_master_token is not defined or consul_acl_master_token == '')
     - not bootstrap_state.stat.exists | bool
+    - consul_node_role == 'server'
 
 - name: Display ACL Master Token
   debug:
     msg: "{{ consul_acl_master_token }}"
   run_once: true
-  when: consul_acl_master_token_display | bool
+  when:
+    - consul_acl_master_token_display | bool
+    - consul_node_role == 'server'
 
 - block:
     - name: Read ACL replication token from previously boostrapped server
@@ -48,6 +54,7 @@
   when:
     - bootstrap_state.stat.exists | bool
     - (consul_acl_replication_token is not defined or consul_acl_replication_token == '')
+    - consul_node_role == 'server'
 
 - block:
   - name: Generate ACL replication token
@@ -58,9 +65,11 @@
   - name: Save ACL replication token
     set_fact:
       consul_acl_replication_token: "{{ consul_acl_replication_token_keygen.stdout }}"
+
   when:
     - (consul_acl_replication_token is not defined or consul_acl_replication_token == '')
     - not bootstrap_state.stat.exists | bool
+    - consul_node_role == 'server'
 
 - name: Create ACL policy configuration
   template:


### PR DESCRIPTION
ACL master token and replication token are just for Consul servers not
for clients.