### PR TITLE
add listen to all the handler tasks

### DIFF
--- a/handlers/reload_consul_conf.yml
+++ b/handlers/reload_consul_conf.yml
@@ -5,3 +5,4 @@
 - name: reload consul configuration on Linux
   command: "pkill --pidfile '{{ consul_run_path }}/consul.pid' --signal SIGHUP"
   when: ansible_os_family != "Windows"
+  listen: 'reload consul configuration'

--- a/handlers/restart_consul.yml
+++ b/handlers/restart_consul.yml
@@ -4,9 +4,11 @@
     name: consul
     state: restarted
   when: ansible_os_family != "Windows"
+  listen: 'restart consul'
 
 - name: restart consul on Windows
   win_nssm:
     name: consul
     state: restarted
   when: ansible_os_family == "Windows"
+  listen: 'restart consul'

--- a/handlers/restart_rsyslog.yml
+++ b/handlers/restart_rsyslog.yml
@@ -4,3 +4,4 @@
     name: rsyslog
     state: restarted
   when: ansible_os_family != "Windows"
+  listen: 'restart rsyslog'

--- a/handlers/restart_syslogng.yml
+++ b/handlers/restart_syslogng.yml
@@ -3,3 +3,4 @@
   service:
     name: syslog-ng
     state: restarted
+  listen: 'restart syslog-ng'

--- a/handlers/start_consul.yml
+++ b/handlers/start_consul.yml
@@ -4,9 +4,11 @@
     name: consul
     state: started
   when: ansible_os_family != "Windows"
+  listen: 'start consul'
 
 - name: start consul on Windows
   win_nssm:
     name: consul
     state: started
   when: ansible_os_family == "Windows"
+  listen: 'start consul'

--- a/handlers/start_snapshot.yml
+++ b/handlers/start_snapshot.yml
@@ -5,3 +5,4 @@
     state: started
     enabled: true
   when: ansible_os_family != "Windows"
+  listen: 'start snapshot'


### PR DESCRIPTION
In Ansible 2.8, the current way that handlers are done (via import_tasks) will be broken (I found out the hard way!).

See: https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/porting_guides/porting_guide_2.8.rst#imports-as-handlers

This PR makes it so that "listen" commands are added to the tasks themselves, as opposed to the import task defined in handlers/main.yml file.

Tested on:
ansible 2.8.0.dev0 (devel f90ec17465) last updated 2019/01/04 07:54:22 (GMT +800)
