### PR TITLE
Adds enable_local_script_checks configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,12 @@ Notice that the dict object has to use precisely the names stated in the documen
 
 - Enable script based checks?
 - Default value: false
+- This is discouraged in favor of `consul_enable_local_script_checks`. 
+
+### `consul_enable_local_script_checks`
+
+- Enable locally defined script checks?
+- Default value: false
 
 ### `consul_raft_protocol`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,7 @@ consul_bootstrap_expect: "{{ lookup('env','CONSUL_BOOTSTRAP_EXPECT') | default(f
 consul_ui: "{{ lookup('env', 'CONSUL_UI') | default(true, true) }}"
 consul_disable_update_check: false
 consul_enable_script_checks: false
+consul_enable_local_script_checks: false
 consul_raft_protocol: "\
   {% if consul_version is version_compare('0.7.0', '<=') %}\
     1\

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -60,6 +60,7 @@
     "syslog_facility": "{{ consul_syslog_facility }}",
     "disable_update_check": {{ consul_disable_update_check | bool | to_json }},
     "enable_script_checks": {{ consul_enable_script_checks | bool | to_json }},
+    "enable_local_script_checks": {{ consul_enable_local_script_checks | bool | to_json }},
 
     {## Encryption and TLS ##}
     {% if consul_encrypt_enable %}

--- a/tests/test_vars.yml
+++ b/tests/test_vars.yml
@@ -83,6 +83,7 @@ consul_bootstrap_expect: "{{ lookup('env','CONSUL_BOOTSTRAP_EXPECT') | default(f
 consul_ui: "{{ lookup('env', 'CONSUL_UI') | default(true, true) }}"
 consul_disable_update_check: false
 consul_enable_script_checks: false
+consul_enable_local_script_checks: false
 consul_raft_protocol: "\
   {% if consul_version is version_compare('0.7.0', '<=') %}\
     1\


### PR DESCRIPTION
- `enable_script_checks` is discouraged in favor of `enable_local_script_checks`.
- Support has been backported as far back as Consul 0.9.4

Please see:

https://www.consul.io/docs/agent/options.html#_enable_script_checks
https://www.hashicorp.com/blog/protecting-consul-from-rce-risk-in-specific-configurations