### PR TITLE
fixed multiarch deployment race condition

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,6 @@
   become: false
   vars:
     ansible_become: false
-  run_once: true
   register: consul_sha256
   tags: installation
 
@@ -49,7 +48,6 @@
   become: false
   vars:
     ansible_become: false
-  run_once: true
   register: consul_package
   tags: installation
 
@@ -63,7 +61,6 @@
   become: false
   vars:
     ansible_become: false
-  run_once: true
   tags: installation
   when: not consul_package.stat.exists | bool
 
@@ -74,21 +71,29 @@
   run_once: true
   when: ansible_os_family == "Alpine"
 
+- name: Create Temporary Directory for Extraction
+  local_action:
+    module: tempfile
+    state: directory
+    prefix: ansible-consul.
+  become: false
+  register: install_temp
+  tags: installation
+
 - name: Unarchive Consul package
   local_action:
     module: unarchive
     src: "{{ role_path }}/files/{{ consul_pkg }}"
-    dest: "{{ role_path }}/files/"
-    creates: "{{ role_path }}/files/consul"
+    dest: "{{ install_temp.path }}/"
+    creates: "{{ install_temp.path }}/consul"
   become: false
   vars:
     ansible_become: false
-  run_once: true
   tags: installation
 
 - name: Install Consul
   copy:
-    src: "{{ role_path }}/files/consul"
+    src: "{{ install_temp.path }}/consul"
     dest: "{{ consul_bin_path }}/consul"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
@@ -104,10 +109,8 @@
     - consul_install_upgrade
 
 - name: Cleanup
-  local_action: file path="{{ item }}" state="absent"
+  local_action: file path="{{ install_temp.path }}" state="absent"
   become: false
   vars:
     ansible_become: false
-  with_fileglob: "{{ role_path }}/files/consul"
-  run_once: true
   tags: installation


### PR DESCRIPTION
Addresses Same Issue with running concurrently on different architectures as https://github.com/brianshumate/ansible-nomad/pull/35

sample before and after results
before
```
$ ansible hashi_client -m shell -a "echo \$(lscpu |head -n1|awk '{print $2}') \$(consul version|head -n1)" --one-line
frankendell.angrybear2.local | CHANGED | rc=0 | (stdout) Architecture: x86_64 Consul v1.4.2
armdocker-4.angrybear2.local | CHANGED | rc=0 | (stdout) Architecture: armv7l Consul v1.4.2
cranbone.angrybear2.local | CHANGED | rc=0 | (stdout) Architecture: aarch64 Consul v1.4.2
```

after
```
$ ansible hashi_client -m shell -a "echo \$(lscpu |head -n1|awk '{print $2}') \$(consul version|head -n1)" --one-line
frankendell.angrybear2.local | CHANGED | rc=0 | (stdout) Architecture: x86_64 Consul v1.4.3
armdocker-4.angrybear2.local | CHANGED | rc=0 | (stdout) Architecture: armv7l Consul v1.4.3
cranbone.angrybear2.local | CHANGED | rc=0 | (stdout) Architecture: aarch64 Consul v1.4.3
```