### PR TITLE
fix consul_bind_address

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -109,7 +109,7 @@ consul_bind_address: "\
   {% elif ansible_os_family == 'Windows'  %}\
     {{ lookup('env','CONSUL_BIND_ADDRESS') | default(hostvars[inventory_hostname]['ansible_ip_addresses'][0], true) }}\
   {% else %}\
-    {{ lookup('env','CONSUL_BIND_ADDRESS') | default(hostvars[inventory_hostname]['ansible_'+ consul_iface ]['ipv4']['address'], true) }}\
+    {{ lookup('env','CONSUL_BIND_ADDRESS') | default(hostvars[inventory_hostname]['ansible_'+ consul_iface | replace('-', '_')]['ipv4']['address'], true) }}\
   {% endif %}"
 consul_advertise_address: "{{ consul_bind_address }}"
 consul_advertise_address_wan: "{{ consul_bind_address }}"


### PR DESCRIPTION
when accessing ipv4 in hostvars, dashes in consul_iface need to be converted to underscores
example:
        "ansible_bond_admin": {
            "active": true,
            "device": "bond-admin",
            "features": {
...
            },
            "hw_timestamp_filters": [],
            "ipv4": {
                "address": "10.1.1.1",
                "broadcast": "10.1.1.255",
                "netmask": "255.255.254.0",
                "network": "10.1.1.0"
            },