### PR TITLE
Support install on Debian Testing

### DIFF
--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -20,8 +20,7 @@
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "Debian"
-    - (ansible_distribution_version != 'buster/sid') and (ansible_distribution_version is version_compare
-(8, '<'))
+    - (ansible_distribution_version != 'buster/sid') and (ansible_distribution_version is version_compare(8, '<'))
 
 - name: Check FreeBSD version
   fail:

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -20,7 +20,8 @@
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "Debian"
-    - ansible_distribution_version is version_compare(8, '<')
+    - (ansible_distribution_version != 'buster/sid') and (ansible_distribution_version is version_compare
+(8, '<'))
 
 - name: Check FreeBSD version
   fail:


### PR DESCRIPTION
On Debian Testing, ansible_distribution_version reports "buster/sid" and not a number as on Debian stable (9.1, 9.2 ...)

So when the assert is run we have an error since we're comparing a number to a string : 
> The conditional check 'ansible_distribution_version is version_compare(8, '<')' failed. The error was: Version comparison: '<' not supported between instances of 'str' and 'int

I fixed this by first asserting that Debian version is not equal to buster/sid and then checking for version number.

I tested this change on Debian 9.7 and Debian testing