### PR TITLE
Check if consul_acl_master_token is empty

### DIFF
--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -16,7 +16,7 @@
 
   when:
     - bootstrap_state.stat.exists | bool
-    - (consul_acl_master_token is not defined or consul_acl_master_token | length == 0 )
+    - (consul_acl_master_token is not defined or consul_acl_master_token | length == 0)
     - consul_node_role == 'server'
 
 - block:
@@ -58,7 +58,7 @@
 
   when:
     - bootstrap_state.stat.exists | bool
-    - (consul_acl_replication_token is not defined)
+    - (consul_acl_replication_token is not defined consul_acl_replication_token | length == 0)
     - consul_node_role == 'server'
 
 - block:
@@ -73,7 +73,7 @@
         consul_acl_replication_token: "{{ consul_acl_replication_token_keygen.stdout }}"
 
   when:
-    - (consul_acl_replication_token is not defined)
+    - (consul_acl_replication_token is not defined or consul_acl_replication_token | length == 0)
     - not bootstrap_state.stat.exists | bool
     - consul_node_role == 'server'
 

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -16,7 +16,7 @@
 
   when:
     - bootstrap_state.stat.exists | bool
-    - (consul_acl_master_token is not defined)
+    - (consul_acl_master_token is not defined or consul_acl_master_token | length == 0 )
     - consul_node_role == 'server'
 
 - block:
@@ -31,7 +31,7 @@
         consul_acl_master_token: "{{ consul_acl_master_token_keygen.stdout }}"
 
   when:
-    - (consul_acl_master_token is not defined)
+    - (consul_acl_master_token is not defined or consul_acl_master_token | length == 0)
     - not bootstrap_state.stat.exists | bool
     - consul_node_role == 'server'
 


### PR DESCRIPTION
Add a check to the ACL tasks to see if the consul_acl_token and the consul_acl_replication_token are empty strings so they can be generated if needed.

This closes #275 