### PR TITLE
Missed an 'or' in replication token check

### DIFF
--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -58,7 +58,7 @@
 
   when:
     - bootstrap_state.stat.exists | bool
-    - (consul_acl_replication_token is not defined consul_acl_replication_token | length == 0)
+    - (consul_acl_replication_token is not or defined consul_acl_replication_token | length == 0)
     - consul_node_role == 'server'
 
 - block:


### PR DESCRIPTION
I missed an or causing the tasks to fail when it tries to run the check