### PR TITLE
Typo in ACL replication

### DIFF
--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -58,7 +58,7 @@
 
   when:
     - bootstrap_state.stat.exists | bool
-    - (consul_acl_replication_token is not or defined consul_acl_replication_token | length == 0)
+    - (consul_acl_replication_token is not defined or consul_acl_replication_token | length == 0)
     - consul_node_role == 'server'
 
 - block:


### PR DESCRIPTION
Their is a blocking typo in ACL task