### PR TITLE
Updated consul_snapshot.json.j2 to handle TLS correctly and fix line …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -192,6 +192,10 @@ consul_tls_verify_incoming_https: false
 consul_tls_verify_server_hostname: false
 consul_tls_files_remote_src: false
 
+consul_tls_min_version: "{{ lookup('env','CONSUL_TLS_MIN_VERSION') | default('tls12', true) }}"
+consul_tls_cipher_suites: ""
+consul_tls_prefer_server_cipher_suites: "{{ lookup('env','CONSUL_TLS_PREFER_SERVER_CIPHER_SUITES') | default('false', true) }}"
+
 ## DNS
 consul_delegate_datacenter_dns: "{{ lookup('env','CONSUL_DELEGATE_DATACENTER_DNS') | default(false, true) }}"
 consul_dnsmasq_enable: "{{ lookup('env','CONSUL_DNSMASQ_ENABLE') | default(false, true) }}"

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -77,6 +77,11 @@
     "verify_outgoing": {{ consul_tls_verify_outgoing | bool | to_json }},
     "verify_incoming_https": {{consul_tls_verify_incoming_https | bool| to_json }},
     "verify_server_hostname": {{ consul_tls_verify_server_hostname | bool | to_json }},
+    "tls_min_version": "{{ consul_tls_min_version }}",
+    {% if consul_tls_cipher_suites is defined and consul_tls_cipher_suites %}
+    "tls_cipher_suites": "{{ vault_tls_cipher_suites}}",
+    {% endif %}
+    "tls_prefer_server_cipher_suites": {{ vault_tls_prefer_server_cipher_suites | bool | to_json }},
     {% endif %}
 
     {## LAN Join ##}

--- a/templates/consul_snapshot.json.j2
+++ b/templates/consul_snapshot.json.j2
@@ -1,11 +1,11 @@
 {
 "snapshot_agent": {
-    "http_addr": "{{ consul_client_address }}:{% if consul_tls_enable | bool %}{{ consul_ports.https }}{% else %}{{ consul_ports.http }}{%endif%}",
-    {%- if consul_tls_enable | bool -%}
+    "http_addr": "{% if consul_tls_enable | bool %}https://{% endif %}{{ consul_client_address }}:{% if consul_tls_enable | bool %}{{ consul_ports.https }}{% else %}{{ consul_ports.http }}{% endif %}",
+    {% if consul_tls_enable | bool -%}
     "ca_file": "{{ consul_tls_dir }}/{{ consul_tls_ca_crt }}",
     "cert_file": "{{ consul_tls_dir }}/{{ consul_tls_server_crt }}",
     "key_file": "{{ consul_tls_dir }}/{{ consul_server_key }}",
-    {%- endif -%}
+    {% endif %}
         "log": {
             "level": "INFO",
             "enable_syslog": true,


### PR DESCRIPTION
…formatting

The current template sets the http_addr to 127.0.0.1:8501 when consul_tls_enable is true. This causes the error below:

> Snapshot agent error: Unexpected response code: 400 (Client sent an HTTP request to an HTTPS server.#012)

To correct this I've added another if check for consul_tls_enable which will append https:// to the front of the consul_client_address value. I also adjusted the whitespace control to format the file.

Before the change the _"ca_file":_ line is appended to the end of the _"http_addr"_ line, as is _"log":_ to the _"key_file":_ line.