### PR TITLE
Add ability to configure cloud-based auto-join

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,6 +142,8 @@ consul_ports:
 consul_group_name: "{{ lookup('env','CONSUL_GROUP_NAME') | default('consul_instances', true) }}"
 consul_join: []
 consul_join_wan: []
+consul_cloud_auto_join: false
+consul_cloud_auto_join_string: "Example at https://www.consul.io/docs/agent/cloud-auto-join.html#amazon-ec2"
 consul_servers: "\
   {% set _consul_servers = [] %}\
   {% for host in groups[consul_group_name] %}\

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -89,12 +89,17 @@
     "retry_max": {{ consul_retry_max | int }},
 
     "retry_join":
-    {% if not consul_retry_join_skip_hosts %}
-      {% for server in _consul_lan_servers %}
-      {%   set _ = consul_join.append(hostvars[server]['consul_advertise_address'] | default(hostvars[server]['consul_bind_address']) | default(hostvars[server]['ansible_default_ipv4']['address']) | mandatory) %}
-      {% endfor %}
-    {% endif %}
+    {% if not consul_cloud_auto_join %}
+    {%  if not consul_retry_join_skip_hosts %}
+      {%  for server in _consul_lan_servers %}
+      {%    set _ = consul_join.append(hostvars[server]['consul_advertise_address'] | default(hostvars[server]['consul_bind_address']) | default(hostvars[server]['ansible_default_ipv4']['address']) | mandatory) %}
+      {%  endfor %}
+    {%  endif %}
     {{ consul_join | map('ipwrap') | list | to_json }},
+    {% else %}
+    {%   set _ = consul_join.append(consul_cloud_auto_join_string) %}
+    {{ consul_join | list | to_json }},
+    {% endif %}
 
     {## Server/Client ##}
     "server": {{ (item.config_version != 'client') | bool | to_json }},


### PR DESCRIPTION
Resolves #303

If someone want to setup auto-joining all what needed is to override 2 variables:

- `consul_cloud_auto_join ` set to `true`
- `consul_cloud_auto_join_string ` set, for example, to `"provider=aws tag_key=Consul tag_value=server"`