### PR TITLE
Fix service restart on upgrades

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -105,12 +105,13 @@
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
     mode: 0755
+  notify:
+    - restart consul
   tags: installation
 
 - name: Daemon reload systemd in case the binaries upgraded
   systemd: daemon_reload=yes
   become: true
-  notify: restart consul
   when:
     - ansible_service_mgr == "systemd"
     - consul_install_upgrade | bool

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -60,13 +60,14 @@
     group: "{{ consul_group }}"
     mode: 0755
   register: consul_install
+  notify:
+    - restart consul
   when: consul_download is changed
   tags: installation
 
 - name: Daemon reload systemd in case the binaries upgraded
   systemd: daemon_reload=yes
   become: true
-  notify: restart consul
   when:
     - ansible_service_mgr == "systemd"
     - consul_install_upgrade | bool


### PR DESCRIPTION
Systemd module doesn't report changes when only using daemon_reload option.
See: https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/system/systemd.py#L388
result['changed'] is only updated when the unit attribute is provided.
Therefore, the notify statement is never called and Consul is not restarted.