### PR TITLE
🐛 Fix for #311 when unzip is not installed on control host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ packages with different package names.
 
 ## Dependencies
 
-Ansible requires GNU tar and this role performs some local use of the unarchive module, so ensure that your system has `gtar` installed and in the PATH.
+Ansible requires GNU tar and this role performs some local use of the unarchive module for efficiency, so ensure that your system has `gtar` and `unzip` installed and in the PATH. If you don't this role will install these on the remote machines to unarchive the ZIP files.
 
 If you're on system with a different (i.e. BSD) `tar`, like macOS and you see odd errors during unarchive tasks, you could be missing `gtar`.
 

--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ packages with different package names.
 
 ## Dependencies
 
-Ansible requires GNU tar and this role performs some local use of the unarchive module for efficiency, so ensure that your system has `gtar` and `unzip` installed and in the PATH. If you don't this role will install these on the remote machines to unarchive the ZIP files.
+Ansible requires GNU tar and this role performs some local use of the unarchive module for efficiency, so ensure that your system has `gtar` and `unzip` installed and in the PATH. If you don't this role will install `unzip` on the remote machines to unarchive the ZIP files.
 
 If you're on system with a different (i.e. BSD) `tar`, like macOS and you see odd errors during unarchive tasks, you could be missing `gtar`.
 

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -85,7 +85,7 @@
 
 # Check for unzip binary
 
-- name: Check if unzip is installed
+- name: Check if unzip is installed on control host
   shell: "command -v unzip -h >/dev/null 2>&1"
   become: false
   changed_when: false
@@ -95,8 +95,8 @@
   ignore_errors: true
   delegate_to: 127.0.0.1
 
-- name: Fail if unzip is not installed on control host
-  fail:
-    msg: "unzip binary is not available in the PATH on the control host."
+- name: Install remotely if unzip is not installed on control host
+  set_fact:
+    consul_install_remotely: true
   when:
     - is_unzip_installed.rc == 1


### PR DESCRIPTION
No need to fail when unzip is not on control host. Installing remotely instead.