### PR TITLE
Added version check for the log_rotate_max_files key added in consul …

### DIFF
--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -64,7 +64,9 @@
     "log_file": "{{ consul_log_path }}/{{ consul_log_file }}",
     "log_rotate_bytes": {{ consul_log_rotate_bytes }},
     "log_rotate_duration": "{{ consul_log_rotate_duration }}",
+    {% if consul_version is version_compare('1.5.3', '>=') %}
     "log_rotate_max_files": {{ consul_log_rotate_max_files }},
+    {% endif %}
     {% endif %}
     "disable_update_check": {{ consul_disable_update_check | bool | to_json }},
     "enable_script_checks": {{ consul_enable_script_checks | bool | to_json }},


### PR DESCRIPTION
…1.5.3

If the consul version is below 1.5.3 it fails to start because this key is not implemented.

On a host using Consul 1.5.1
[root@consul01 jneurohr]# /usr/local/bin/consul validate /etc/consul/config.json                                                                                             Config validation failed: Error parsing /etc/consul/config.json: 1 error occurred:                                                                                                   * invalid config key log_rotate_max_files

https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#153-july-25-2019
https://www.consul.io/docs/agent/options.html#_log_rotate_max_files