### PR TITLE
Fix start service on Windows

### DIFF
--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -142,14 +142,20 @@
         name: nssm
         state: present
 
-    - name: (Windows) Start Consul on Windows
+    - name: (Windows) Create Consul service on Windows
       win_nssm:
         name: consul
-        state: started
+        state: present
         application: "{{ consul_binary }}"
         app_parameters_free_form: "agent -config-file={{ consul_config_path }}/config.json -config-dir={{ consul_configd_path }}"
         stdout_file: "{{ consul_log_path }}/consul-nssm-output.log"
         stderr_file: "{{ consul_log_path }}/consul-nssm-error.log"
+
+    - name: (Windows) start consul on windows
+      win_service:
+        name: consul
+       	start_mode: auto
+        state: started
 
     - name: (Windows) Check Consul HTTP API
       win_wait_for:

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -154,7 +154,7 @@
     - name: (Windows) start consul on windows
       win_service:
         name: consul
-       	start_mode: auto
+        start_mode: auto
         state: started
 
     - name: (Windows) Check Consul HTTP API


### PR DESCRIPTION
When on Windows platform, separating create and start service tasks gives better result.
It often fails on first start, if service is not created prematurely.