### PR TITLE
Ensure that custom config will not be deleted

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -35,7 +35,7 @@
     - consul_config_custom is defined
   notify:
     - restart consul
-    
+
 - name: Set fact list with custom configuration file
   set_fact:
     managed_files: "{{ managed_files |default([]) }} + \

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -35,3 +35,8 @@
     - consul_config_custom is defined
   notify:
     - restart consul
+    
+- name: Set fact list with custom configuration file
+  set_fact:
+    managed_files: "{{ managed_files |default([]) }} + \
+      [ '{{ consul_configd_path }}/50custom.json' ]"

--- a/tasks/config_windows.yml
+++ b/tasks/config_windows.yml
@@ -31,3 +31,8 @@
     - consul_config_custom is defined
   notify:
     - restart consul
+
+- name: Set fact list with custom configuration file
+  set_fact:
+    managed_files: "{{ managed_files |default([]) }} + \
+      [ '{{ consul_configd_path }}/50custom.json' ]"


### PR DESCRIPTION
Specifying `consul_services` will lead to custom config being deleted. In order to prevent this there is a fact that needs to be set