### PR TITLE
🐛 Fix for #270 with_fileglob evaluates a local path.

### DIFF
--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -75,7 +75,6 @@
 
 - name: Cleanup
   file:
-    path: "{{ item }}"
+    path: "/tmp/consul"
     state: absent
-  with_fileglob: "/tmp/consul/*"
   tags: installation


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/10671559/65593136-317bea80-df90-11e9-8c08-48fee43aaa3e.png)


documentation with_fileglob 
> Matching is against local system files on the Ansible controller. 

https://docs.ansible.com/ansible/latest/plugins/lookup/fileglob.html?highlight=with_fileglob

install_remote.yml can use this simple cleanup.