### PR TITLE
Fix for #325 for Consul > 1.4.0 Read ACL replication token from previously boostrapped server

### DIFF
--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -49,8 +49,8 @@
     - name: Read ACL replication token from previously boostrapped server
       shell: >
         cat {{ consul_config_path }}/config.json |
-        grep "acl_replication_token" |
-        sed -E 's/"acl_replication_token": "(.+)",?/\1/' |
+        grep "replication" |
+        sed -E 's/"replication": "(.+)",?/\1/' |
         sed 'is/^ *//;s/ *$//'
       changed_when: false
       check_mode: false


### PR DESCRIPTION
To get the replication token from config.json the grep utility is used with a search string. The problem is that this string changed in Consul 1.4.0 and the search no longer works. This PR has a search string that works in either case.