### PR TITLE
Flush handlers at the end of the main. Fix for #253.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,3 +52,6 @@
   when: consul_services is defined and consul_services|length>0
   tags:
     - consul_services
+
+- name: flush_handlers
+  meta: flush_handlers


### PR DESCRIPTION
As handlers are PLAY-scoped and not ROLE-scoped on Ansible.
It could be a good practice to add a [meta flush handler](https://docs.ansible.com/ansible/latest/modules/meta_module.html)
at the end of the main task. So we are sure that the DNS config is up
for next roles in the play.

https://docs.ansible.com/ansible/latest/modules/meta_module.html

