### PR TITLE
ensure enable_tag_override is json

### DIFF
--- a/templates/service.json.j2
+++ b/templates/service.json.j2
@@ -11,7 +11,7 @@
         "address": "{{ item.address }}",
         {% endif -%}
         {% if item.enable_tag_override is defined -%}
-        "enable_tag_override": {{ item.enable_tag_override }},
+        "enable_tag_override": {{ item.enable_tag_override | bool | to_json }},
         {% endif -%}
         {% if item.kind is defined -%}
         "kind": "{{ item.kind }}",


### PR DESCRIPTION
Setting `enable_tag_override` to a boolean in the yaml will result in python printing `True` into the template, which is not valid json.

This change is not backwards compatible for users who were using a service description with before.

```
consul_services:
  - name: name
    ...
    enable_tag_override: "true"
```

What is now supported and in my opinion better:

```
consul_services:
  - name: name
    ...
    enable_tag_override: true
```
