### PR TITLE
Remove errant 'i' from sed, causing corrupt config

### DIFF
--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -53,7 +53,7 @@
         cat {{ consul_config_path }}/config.json |
         grep "replication" |
         sed -E 's/"replication": "(.+)",?/\1/' |
-        sed 'is/^ *//;s/ *$//'
+        sed 's/^ *//;s/ *$//'
       changed_when: false
       check_mode: false
       register: consul_acl_replication_token_read


### PR DESCRIPTION
It looks like this was accidentally added when cleaning up this area in e2f738022648755b727f51c0ef5dc99cd3732a5e. This insert had no effect on the first run (or if a replication key was statically defined), but on subsequent runs the replication token would contain this sed pattern and a newline, causing the JSON prettify-ing of config.json to fail. This ultimately left the config corrupt and broke other key discovery methods on further runs.

Before this patch (debug output):

```ansible
ok: [consul-0] => {
    "consul_acl_replication_token": "s/^ *//;s/ *$//\n            d6ac41c2-7f46-428c-9391-a80aa1d8525b"
}
```

After this patch:
```plaintext
ok: [consul-0] => {
    "consul_acl_replication_token": "d6ac41c2-7f46-428c-9391-a80aa1d8525b"
}
```

This is perhaps related to GH issue brianshumate/ansible-consul#160