### PR TITLE
Add 'changed_when: false' to ACL master lookup

### DIFF
--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -6,6 +6,7 @@
       command: "cat {{ consul_config_path }}/config.json"
       register: config_read
       no_log: true
+      changed_when: false
       run_once: true
 
     - name: Save acl_master_token from existing configuration


### PR DESCRIPTION
Context: ACLs enabled, using generated tokens

Without this, this resource shows up as changed for every run, even when nothing was changed. This is the same approach used below in this file on the 'Read ACL replication token from...' resource.