### PR TITLE
Use generated password as token UUID source

### DIFF
--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -23,7 +23,7 @@
 - block:
 
     - name: Generate ACL master token
-      command: "echo {{ ansible_date_time.iso8601_micro | to_uuid }}"
+      command: "echo {{ lookup('password', '/dev/null length=32 chars=ascii_letters') | to_uuid }}"
       register: consul_acl_master_token_keygen
       run_once: true
       no_log: true
@@ -71,7 +71,7 @@
 - block:
 
     - name: Generate ACL replication token
-      command: "echo {{ ansible_date_time.iso8601_micro | to_uuid }}"
+      command: "echo {{ lookup('password', '/dev/null length=32 chars=ascii_letters') | to_uuid }}"
       register: consul_acl_replication_token_keygen
       no_log: true
       run_once: true


### PR DESCRIPTION
I'm admittedly not familiar with the internals of "to_uuid", but if it doesn't add any additional randomness source then it might be possible to discover the generated tokens if you knew when the tokens were first generated.

This uses a generated password that [seems to use the OS randomness source](https://github.com/ansible/ansible/blob/4817dcd0fce5cd639e5baf8794bb99e302031739/lib/ansible/utils/encrypt.py#L50) which is more appropriate for a secret token.