### PR TITLE
Change capability of consul to bind port < 1024

### DIFF
--- a/templates/consul_systemd.service.j2
+++ b/templates/consul_systemd.service.j2
@@ -36,6 +36,7 @@ RestartSec={{ consul_systemd_restart_sec }}s
 Environment={{ var }}
 {% endfor %}
 LimitNOFILE={{ consul_systemd_limit_nofile }}
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hello,

Currently it's not possible to start consul with a non root user.
I added an option in the systemd configuration.

Resolve #353

Thanks.