### PR TITLE
Document consul_manage_user and consul_manage_group in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,20 @@ Many role variables can also take their values from environment variables as wel
 - Default Linux value: consul
 - Default Windows value: LocalSystem
 
+### `consul_manage_user`
+
+- Whether to create the user defined by `consul_user` or not
+- Default value: true
+
 ### `consul_group`
 
 - OS group
 - Default value: bin
+
+### `consul_manage_group`
+
+- Whether to create the group defined by `consul_group` or not
+- Default value: false
 
 ### `consul_group_name`
 


### PR DESCRIPTION
This PR adds the currently undocumented defaults vars `consul_manage_user` and `consul_manage_group` to the README. As it is sometimes handy or desired to change the default group `bin` users might get confused why the group is not automatically created for them. I had to look up the actual task and logic to find out about `consul_manage_group`. I think it makes sense to expose this functionality in the README.