### PR TITLE
Encrypt verify connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ Notice that the dict object has to use precisely the names stated in the documen
 ### `consul_encrypt_verify_incoming`
 
 - Verify incoming Gossip connections
-- Default value: false
+- Default value: true
 
 ### `consul_encrypt_verify_outgoing`
 

--- a/README.md
+++ b/README.md
@@ -562,6 +562,16 @@ Notice that the dict object has to use precisely the names stated in the documen
 - Enable Gossip Encryption
 - Default value: true
 
+### `consul_encrypt_verify_incoming`
+
+- Verify incoming Gossip connections
+- Default value: false
+
+### `consul_encrypt_verify_outgoing`
+
+- Verify outgoing Gossip connections
+- Default value: true
+
 ### `consul_disable_keyring_file`
 
 - If set, the keyring will not be persisted to a file. Any installed keys will be lost on shutdown, and only the given -encrypt key will be available on startup.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -187,7 +187,7 @@ consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') |
 
 ## gossip encryption
 consul_encrypt_enable: "{{ lookup('env','CONSUL_ENCRYPT_ENABLE') | default(true, true) }}"
-consul_encrypt_verify_incoming: false
+consul_encrypt_verify_incoming: true
 consul_encrypt_verify_outgoing: true
 consul_disable_keyring_file: "{{ lookup('env','CONSUL_DISABLE_KEYRING_FILE') | default(false, true) }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -187,6 +187,8 @@ consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') |
 
 ## gossip encryption
 consul_encrypt_enable: "{{ lookup('env','CONSUL_ENCRYPT_ENABLE') | default(true, true) }}"
+consul_encrypt_verify_incoming: false
+consul_encrypt_verify_outgoing: true
 consul_disable_keyring_file: "{{ lookup('env','CONSUL_DISABLE_KEYRING_FILE') | default(false, true) }}"
 
 ## TLS

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -78,8 +78,8 @@
     {## Encryption and TLS ##}
     {% if consul_encrypt_enable | bool %}
     "encrypt": "{{ consul_raw_key }}",
-    "encrypt_verify_incoming": "{{ consul_encrypt_verify_incoming }}",
-    "encrypt_verify_outgoing": "{{ consul_encrypt_verify_outgoing }}",
+    "encrypt_verify_incoming": "{{ consul_encrypt_verify_incoming | bool | to_json }}",
+    "encrypt_verify_outgoing": "{{ consul_encrypt_verify_outgoing | bool | to_json }}",
     {% endif %}
     {% if consul_disable_keyring_file | bool %}
     "disable_keyring_file": true,

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -78,8 +78,8 @@
     {## Encryption and TLS ##}
     {% if consul_encrypt_enable | bool %}
     "encrypt": "{{ consul_raw_key }}",
-    "encrypt_verify_incoming": "{{ consul_encrypt_verify_incoming | bool | to_json }}",
-    "encrypt_verify_outgoing": "{{ consul_encrypt_verify_outgoing | bool | to_json }}",
+    "encrypt_verify_incoming": {{ consul_encrypt_verify_incoming | bool | to_json }},
+    "encrypt_verify_outgoing": {{ consul_encrypt_verify_outgoing | bool | to_json }},
     {% endif %}
     {% if consul_disable_keyring_file | bool %}
     "disable_keyring_file": true,

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -78,6 +78,8 @@
     {## Encryption and TLS ##}
     {% if consul_encrypt_enable | bool %}
     "encrypt": "{{ consul_raw_key }}",
+    "encrypt_verify_incoming": "{{ consul_encrypt_verify_incoming }}",
+    "encrypt_verify_outgoing": "{{ consul_encrypt_verify_outgoing }}",
     {% endif %}
     {% if consul_disable_keyring_file | bool %}
     "disable_keyring_file": true,

--- a/tests/test_vars.yml
+++ b/tests/test_vars.yml
@@ -167,6 +167,8 @@ consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') |
 
 ## gossip encryption
 consul_encrypt_enable: "{{ lookup('env','CONSUL_ENCRYPT_ENABLE') | default(true, true) }}"
+consul_encrypt_verify_incoming: false
+consul_encrypt_verify_outgoing: true
 consul_disable_keyring_file: "{{ lookup('env','CONSUL_DISABLE_KEYRING_FILE') | default(false, true) }}"
 
 ## TLS

--- a/tests/test_vars.yml
+++ b/tests/test_vars.yml
@@ -167,7 +167,7 @@ consul_acl_replication_token: "{{ lookup('env','CONSUL_ACL_REPLICATION_TOKEN') |
 
 ## gossip encryption
 consul_encrypt_enable: "{{ lookup('env','CONSUL_ENCRYPT_ENABLE') | default(true, true) }}"
-consul_encrypt_verify_incoming: false
+consul_encrypt_verify_incoming: true
 consul_encrypt_verify_outgoing: true
 consul_disable_keyring_file: "{{ lookup('env','CONSUL_DISABLE_KEYRING_FILE') | default(false, true) }}"
 


### PR DESCRIPTION
Add **encrypt_verify_incoming** and **encrypt_verify_outgoing** parameters in the list of customizable parameters.

**encrypt_verify_incoming** - This is an optional parameter that can be used to disable enforcing encryption for incoming gossip in order to upshift from unencrypted to encrypted gossip on a running cluster. See this section for more information. Defaults to true.

**encrypt_verify_outgoing** - This is an optional parameter that can be used to disable enforcing encryption for outgoing gossip in order to upshift from unencrypted to encrypted gossip on a running cluster. See this section for more information. Defaults to true.
