### PR TITLE
Use consul_node_name empty by default to use hostname of the current server

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,8 +409,10 @@ Notice that the dict object has to use precisely the names stated in the documen
 
 ### `consul_node_name`
 
-- Node name (should not include dots)
-- Default value: `{{ inventory_hostname_short }}`
+- Define a custom node name (should not include dots)
+  See [node_name](https://www.consul.io/docs/agent/options.html#node_name)
+  - The default value on Consul is the hostname of the server.
+- Default value: '' 
 
 ### `consul_recursors`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,7 +75,6 @@ consul_iface: "\
   {% else %}\
     {{ lookup('env','CONSUL_IFACE') | default(ansible_default_ipv4.interface, true) }}\
   {% endif %}"
-consul_node_name: "{{ ansible_hostname }}"
 consul_node_role: "{{ lookup('env','CONSUL_NODE_ROLE') | default('client', true) }}"
 consul_recursors: "{{ lookup('env','CONSUL_RECURSORS') | default('[]', true) }}"
 consul_bootstrap_expect: "{{ lookup('env','CONSUL_BOOTSTRAP_EXPECT') | default(false, true) }}"

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -4,7 +4,9 @@
     {# Common Settings #}
 
     {## Node ##}
+    {% if consul_node_name is defined %}
     "node_name": "{{ consul_node_name }}",
+    {% endif %}
     "datacenter": "{{ consul_datacenter }}",
     "domain": "{{ consul_domain }}",
     {% if consul_alt_domain %}

--- a/tests/test_vars.yml
+++ b/tests/test_vars.yml
@@ -77,7 +77,6 @@ consul_iface: "\
   {% else %}\
     {{ lookup('env','CONSUL_IFACE') | default(ansible_default_ipv4.interface, true) }}\
   {% endif %}"
-consul_node_name: "{{ inventory_hostname_short }}"
 consul_node_role: "{{ lookup('env','CONSUL_NODE_ROLE') | default('client', true) }}"
 consul_recursors: "{{ lookup('env','CONSUL_RECURSORS') | default('[]', true) }}"
 consul_bootstrap_expect: "{{ lookup('env','CONSUL_BOOTSTRAP_EXPECT') | default(false, true) }}"


### PR DESCRIPTION
Related to this issue that I opened yesterday: https://github.com/brianshumate/ansible-consul/issues/371

I think that we can use the default behaviour of Consul to set up the `node_name` but keep the possibility to override it with the Ansible variable `consul_node_name`

The case is that when we build machine images with Consul installed inside, the `node_name` is the hostname of the server used to build the machine image. After that, the node_name will be the same for all VMs created from this machine image and cannot be changed automatically.

What do you think about that?

I'm interested to have feedbacks about it
