### PR TITLE
Setup the role to be used in check mode

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -67,6 +67,7 @@
   when: not consul_package.stat.exists | bool
   run_once: true
   delegate_to: 127.0.0.1
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Update Alpine Package Manager (APK)
   apk:
@@ -97,6 +98,7 @@
     ansible_become: false
   tags: installation
   delegate_to: 127.0.0.1
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Install Consul
   copy:
@@ -108,9 +110,11 @@
   notify:
     - restart consul
   tags: installation
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Daemon reload systemd in case the binaries upgraded
-  systemd: daemon_reload=yes
+  systemd:
+    daemon_reload: yes
   become: true
   when:
     - ansible_service_mgr == "systemd"
@@ -126,3 +130,4 @@
   tags: installation
   run_once: true
   delegate_to: 127.0.0.1
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -53,6 +53,7 @@
     state: absent
   when: ansible_os_family != 'Windows' and item not in managed_files
   with_items: "{{ list_current_service_config }}"
+  ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - restart consul
 
@@ -62,5 +63,6 @@
     state: absent
   when: ansible_os_family == 'Windows' and item not in managed_files
   with_items: "{{ list_current_service_config }}"
+  ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - restart consul


### PR DESCRIPTION
As some users are using check mode to be sure that Ansible tasks are correctly done, we can set up the role to work with this mode

For that, we have to ignore alerts on tasks that need a real change on the system (for example move a file that is created in the task before will fail in check mode)

What do you think about that?