### PR TITLE
Added support for Alpine

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
+          - alpine-3.11
           - centos-6
           - centos-7
           - centos-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ virtualenv:
 services: docker
 
 env:
+  - SCENARIO=alpine-3.11
   - SCENARIO=centos-6
   - SCENARIO=centos-7
   - SCENARIO=centos-8

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Many role variables can also take their values from environment variables as wel
 
 - Run path for process identifier (PID) file
 - Default Linux value: `/run/consul`
+- Default Alpine value: `/var/run`
+    - This value cannot be overwritten on Alpine.[See](https://github.com/OpenRC/openrc/blob/master/service-script-guide.md#dont-let-the-user-control-the-pid-file-location)
 - Default Windows value: `C:\ProgramData\consul`
 
 ### `consul_user`

--- a/molecule/alpine-3.11/molecule.yml
+++ b/molecule/alpine-3.11/molecule.yml
@@ -1,0 +1,14 @@
+---
+scenario:
+  name: alpine-3.11
+platforms:
+  - name: alpine-3.11
+    groups:
+      - consul_instances
+    image: alpine:3.11
+    dockerfile: ../_shared/Dockerfile.j2
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -157,6 +157,15 @@
     mode: 0755
   when: ansible_os_family == "FreeBSD"
 
+- name: Create OPENRC init script
+  template:
+    src: consul_openrc.j2
+    dest: /etc/init.d/consul
+    owner: root
+    group: root
+    mode: 0755
+  when: ansible_os_family == "Alpine"
+
 - name: Create SYSV init script
   template:
     src: consul_sysvinit.j2
@@ -166,6 +175,7 @@
     mode: 0755
   when:
     - not ansible_service_mgr == "systemd"
+    - not ansible_os_family == "Alpine"
     - not ansible_os_family == "Debian"
     - not ansible_os_family == "FreeBSD"
     - not ansible_os_family == "Solaris"

--- a/templates/consul_openrc.j2
+++ b/templates/consul_openrc.j2
@@ -1,0 +1,61 @@
+#!/sbin/openrc-run
+
+name=consul
+description="Consul service discovery framework"
+description_checkconfig="Verify consul configuration"
+daemon={{ consul_bin_path }}/consul
+daemon_user={{ consul_user }}
+daemon_group={{ consul_group }}
+extra_commands="checkconfig"
+pidfile="{{ consul_run_path }}/consul.pid"
+
+CONSUL_LOG_FILE="/var/log/${SVCNAME}.log"
+CONSUL_CONFIG={{ consul_config_path }}/config.json
+CONSUL_CONFIGD={{ consul_configd_path }}
+{% if consul_ui_legacy %}
+CONSUL_UI_LEGACY=true
+{% endif %}
+
+depend() {
+    need net
+    after firewall
+}
+
+checkconfig() {
+    ebegin "Checking $CONSUL_CONFIG"
+    $daemon validate $CONSUL_CONFIG
+    eend $?
+}
+
+start_pre() {
+    checkconfig
+    checkpath -f -m 0640 -o ${daemon_user}:${daemon_group} "$CONSUL_LOG_FILE"
+}
+
+start() {
+    checkconfig || return 1
+
+    ebegin "Starting ${name}"
+        start-stop-daemon --start \
+            --user ${daemon_user} --group ${daemon_group} \
+            --make-pidfile --pidfile ${pidfile} \
+            -b --stdout ${CONSUL_LOG_FILE} --stderr ${CONSUL_LOG_FILE} \
+            --exec ${daemon} -- agent --config-file="${CONSUL_CONFIG}" -config-dir="${CONSUL_CONFIGD}"
+    eend $?
+}
+
+stop() {
+    ebegin "Stopping ${name}"
+        start-stop-daemon --stop --quiet \
+            --pidfile ${pidfile} \
+            --exec ${daemon}
+    eend $?
+}
+
+
+reload() {
+    start_pre \
+        && ebegin "Reloading ${name} configuration" \
+        && supervise-daemon ${name} --signal HUP --pidfile ${pidfile}
+    eend $?
+}

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -7,4 +7,4 @@ consul_syslog_enable: false
 
 # PID file location should not be configurable for openrc
 # Ref: https://github.com/OpenRC/openrc/blob/master/service-script-guide.md#dont-let-the-user-control-the-pid-file-location
-consul_run_path: /var/run
+consul_run_path: "/var/run"

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -4,3 +4,7 @@ consul_os_packages:
   - git
   - unzip
 consul_syslog_enable: false
+
+# PID file location should not be configurable for openrc
+# Ref: https://github.com/OpenRC/openrc/blob/master/service-script-guide.md#dont-let-the-user-control-the-pid-file-location
+consul_run_path: /var/run

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,0 +1,6 @@
+---
+# File: Alpine.yml - Alpine variables for Consul
+consul_os_packages:
+  - git
+  - unzip
+consul_syslog_enable: false

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -3,6 +3,7 @@
 consul_os_packages:
   - git
   - unzip
+  - openrc
 consul_syslog_enable: false
 
 # PID file location should not be configurable for openrc


### PR DESCRIPTION
Hello, thank you for the great role.

I had to make a few changes to get this role running correctly on Alpine 3.11. 

- Introduced an Alpine variables file 
- Started using OpenRC for the service init scripts. I was initially modifying the sysvinit script however it ended up having so many "if alpine" blocks that it made more sense to introduce an openrc script.

I had to make a call whether consul_run_path was configurable as in the openrc best practices guide it highly recommends against it. I decided to force to /var/run on alpine to keep it standard and added a note to the readme. 

Let me know if I need to make any improvements.