### PR TITLE
Update molecule to v3 schema

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,4 @@
+---
 extends: default
 
 rules:

--- a/molecule/_shared/base.yml
+++ b/molecule/_shared/base.yml
@@ -13,8 +13,7 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: yamllint
 provisioner:
   name: ansible
   config_options:

--- a/molecule/_shared/base.yml
+++ b/molecule/_shared/base.yml
@@ -13,7 +13,8 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint: yamllint
+lint: |
+  yamllint .
 provisioner:
   name: ansible
   config_options:


### PR DESCRIPTION
Hi,

Molecule has updated their schema in v3 and has updated the lint property to be a string.

     # old v2 format, no longer supported
    lint:
      name: yamllint
      enabled: true

    # new format
    lint: yamllint

See: https://molecule.readthedocs.io/en/latest/configuration.html#lint

Without this change the Travis CI build fails on master with the following error:
    
    ERROR: Failed to pre-validate.
    {'lint': ['must be of string type']}

See: https://travis-ci.org/brianshumate/ansible-consul/jobs/653611219?utm_medium=notification&utm_source=github_status