### PR TITLE
Molecule 2.22 is used, 3 breaks in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ cache:
 
 install:
   # Install test dependencies.
-  - pip install molecule[docker] netaddr
+  - pip3 install -r requirements.txt
 
 script:
   - molecule --base-config molecule/_shared/base.yml test --scenario-name ${SCENARIO}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+molecule===2.22
+docker
+netaddr
+testinfra
+flake8
+yamllint


### PR DESCRIPTION
TODO: Upgrade to 3 using the [migration guide ](https://github.com/ansible-community/molecule/issues/2560).