### PR TITLE
Fix unarchive consul package to run_once

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -96,6 +96,7 @@
   vars:
     ansible_become: false
   tags: installation
+  run_once: true
   delegate_to: 127.0.0.1
 
 - name: Install Consul


### PR DESCRIPTION
This PR adds run_once: true to the task "_Unarchive Consul package_" of role "_install.yml_". The task is delegated to 127.0.0.1.  

When running role on several machines, it works for the first machine and then for the other machines, we get the following error : 

> An exception occurred during task execution. To see the full traceback, use -vvv. The error was: __main__.UnarchiveError: Cannot change group ownership of consul" 

because package is already unarchived on localhost.