### PR TITLE
add leave_on_terminate

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,9 @@ packages with different package names.
 - [RPC hold timeout](https://www.consul.io/docs/agent/options.html#rpc_hold_timeout) is the duration that a client or server will retry internal RPC requests during leader elections
 - Default value: 7s
 
+#### `leave_on_terminate`
+- [leave_on_terminate](https://www.consul.io/docs/agent/options.html#leave_on_terminate) If enabled, when the agent receives a TERM signal, it will send a Leave message to the rest of the cluster and gracefully leave. The default behavior for this feature varies based on whether or not the agent is running as a client or a server. On agents in client-mode, this defaults to true and for agents in server-mode, this defaults to false.
+
 ## Dependencies
 
 Ansible requires GNU tar and this role performs some local use of the unarchive module for efficiency, so ensure that your system has `gtar` and `unzip` installed and in the PATH. If you don't this role will install `unzip` on the remote machines to unarchive the ZIP files.

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -74,6 +74,9 @@
     "disable_update_check": {{ consul_disable_update_check | bool | to_json }},
     "enable_script_checks": {{ consul_enable_script_checks | bool | to_json }},
     "enable_local_script_checks": {{ consul_enable_local_script_checks | bool | to_json }},
+    {% if leave_on_terminate is defined %}
+    "leave_on_terminate": {{ leave_on_terminate | bool | to_json }},
+    {% endif %}
 
     {## Encryption and TLS ##}
     {% if consul_encrypt_enable | bool %}


### PR DESCRIPTION
Add `leave_on_terminate` to monitor which consul client or consul server dies if we don't want to leave when machine shutdown. 
https://www.consul.io/docs/agent/options.html#leave_on_terminate