### PR TITLE
Corrected version Fedora dropped libselinux-python.

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,7 +2,7 @@
 # File: RedHat.yml - Red Hat OS variables for Consul
 
 consul_os_packages:
-  - "{% if ( ansible_distribution  == 'Fedora' and ansible_distribution_version is version('27', '<') ) or \
+  - "{% if ( ansible_distribution  == 'Fedora' and ansible_distribution_version is version('28', '<') ) or \
       ( ansible_distribution  == 'CentOS' and ansible_distribution_version is version('8', '<') ) or \
       ( ansible_distribution  == 'OracleLinux' and ansible_distribution_version is version('8', '<') ) \
     %}\

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,7 +2,7 @@
 # File: RedHat.yml - Red Hat OS variables for Consul
 
 consul_os_packages:
-  - "{% if ( ansible_distribution  == 'Fedora' and ansible_distribution_version is version('28', '>') ) or \
+  - "{% if ( ansible_distribution  == 'Fedora' and ansible_distribution_version is version('28', '<') ) or \
       ( ansible_distribution  == 'CentOS' and ansible_distribution_version is version('8', '<') ) or \
       ( ansible_distribution  == 'OracleLinux' and ansible_distribution_version is version('8', '<') ) \
     %}\

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,7 +2,7 @@
 # File: RedHat.yml - Red Hat OS variables for Consul
 
 consul_os_packages:
-  - "{% if ( ansible_distribution  == 'Fedora' and ansible_distribution_version is version('31', '<') ) or \
+  - "{% if ( ansible_distribution  == 'Fedora' and ansible_distribution_version is version('27', '<') ) or \
       ( ansible_distribution  == 'CentOS' and ansible_distribution_version is version('8', '<') ) or \
       ( ansible_distribution  == 'OracleLinux' and ansible_distribution_version is version('8', '<') ) \
     %}\

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,7 +2,7 @@
 # File: RedHat.yml - Red Hat OS variables for Consul
 
 consul_os_packages:
-  - "{% if ( ansible_distribution  == 'Fedora' and ansible_distribution_version is version('28', '<') ) or \
+  - "{% if ( ansible_distribution  == 'Fedora' and ansible_distribution_version is version('28', '>') ) or \
       ( ansible_distribution  == 'CentOS' and ansible_distribution_version is version('8', '<') ) or \
       ( ansible_distribution  == 'OracleLinux' and ansible_distribution_version is version('8', '<') ) \
     %}\


### PR DESCRIPTION
Fedora switched to python3-libselinux at version 28.