### PR TITLE
Allow Role to run when become_method is su

### DIFF
--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -88,6 +88,8 @@
 - name: Check if unzip is installed on control host
   shell: "command -v unzip -h >/dev/null 2>&1"
   become: false
+  vars:
+    ansible_become: false
   changed_when: false
   check_mode: false
   run_once: true


### PR DESCRIPTION
This allows the check for unzip to run when the become_method is set to *su* in a global ansible project and the *su* required a password.