### PR TITLE
Use AmbientCapabilities in systemd template

### DIFF
--- a/templates/consul_systemd.service.j2
+++ b/templates/consul_systemd.service.j2
@@ -36,7 +36,7 @@ RestartSec={{ consul_systemd_restart_sec }}s
 Environment={{ var }}
 {% endfor %}
 LimitNOFILE={{ consul_systemd_limit_nofile }}
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### WHAT
Use AmbientCapabilities to grant CAP_NET_BIND_SERVICE capability.  

### WHY
When Consul runs as any non-root user, and tries to bind to system ports (<1024), we need explicit grant of capabilities.
https://unix.stackexchange.com/a/581337/177343

The use case for this is when:

1. In a systemd environment, where DNS resolution services are provided by `systemd-resolved`
1. We want Consul to answer `.consul` DNS queries,
1. And we don't want to install `dnsmasq` just to route DNS requests to the Consul service.

To achieve the above 3 requirements, we can create a Dummy network interface where Consul can be configured to listen for DNS queries.  However, this would require listening on port 53, hence the requirement for `AmbientCapabilities`.

### MORE INFO
Additional info for this `dnsmasq`-less approach is listed here: https://gist.github.com/kquinsland/5cdc63614a581d9b392f435740b58729