### PR TITLE
Prevent gathering facts for the same servers in loop. Added run_once …

### DIFF
--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -8,6 +8,7 @@
   delegate_facts: true
   with_items: "{{ consul_servers | difference(play_hosts) }}"
   ignore_errors: true
+  run_once: true
   when: consul_gather_server_facts | bool
 
 - name: Expose advertise_address(_wan) datacenter and node_role as facts


### PR DESCRIPTION
If playbook executed for many servers each server interaction will start checking Consul servers facts.

Was added run_once option to prevent not necessary duplicated ssh connections.