### PR TITLE
Allow "Connect" for any and all nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Notice that the dict object has to use precisely the names stated in the documen
 - Define a custom node name (should not include dots)
   See [node_name](https://www.consul.io/docs/agent/options.html#node_name)
   - The default value on Consul is the hostname of the server.
-- Default value: '' 
+- Default value: ''
 
 ### `consul_recursors`
 
@@ -1093,7 +1093,7 @@ consul3.node.consul.  0 IN  A 10.1.42.230
 
 ### `consul_connect_enabled`
 
-- Enable Consul Connect feature on servers
+- Enable Consul Connect feature
 - Default value: false
 
 ### iptables DNS Forwarding Support

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -125,7 +125,7 @@
     "server": {{ (item.config_version != 'client') | bool | to_json }},
 
     {## Enable Connect on Server ##}
-    {% if (item.config_version != 'client') and consul_connect_enabled %}
+    {% if consul_connect_enabled | bool %}
     "connect": {
         "enabled": true
     },


### PR DESCRIPTION
The 'consul_connect_enabled' is now the root of truth for allowing
Consul connect functionality. This remediates the current functionality
where Connect is only allowed on Consul SERVER nodes.

Addresses https://github.com/ansible-community/ansible-consul/issues/400