### PR TITLE
add auto_encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,22 @@ Notice that the dict object has to use precisely the names stated in the documen
   - Can be overridden with `CONSUL_TLS_PREFER_SERVER_CIPHER_SUITES` environment variable
 - Default value: false
 
+### `auto_encrypt`
+- [Auto encrypt](https://www.consul.io/docs/agent/options#auto_encrypt)
+- Default value:
+```yaml
+auto_encrypt:
+  enabled: false
+```
+- Example:
+
+```yaml
+auto_encrypt:
+  enabled: true
+  dns_san: ["consul.com"]
+  ip_san: ["127.0.0.1"]
+```
+
 ### `consul_install_remotely`
 
 - Whether to download the files for installation directly on the remote hosts

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -207,6 +207,8 @@ consul_tls_files_remote_src: false
 consul_tls_min_version: "{{ lookup('env','CONSUL_TLS_MIN_VERSION') | default('tls12', true) }}"
 consul_tls_cipher_suites: ""
 consul_tls_prefer_server_cipher_suites: "{{ lookup('env','CONSUL_TLS_PREFER_SERVER_CIPHER_SUITES') | default('false', true) }}"
+auto_encrypt:
+  enabled: false
 
 ## DNS
 consul_delegate_datacenter_dns: "{{ lookup('env','CONSUL_DELEGATE_DATACENTER_DNS') | default(false, true) }}"

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -103,6 +103,22 @@
     "tls_cipher_suites": "{{ consul_tls_cipher_suites}}",
     {% endif %}
     "tls_prefer_server_cipher_suites": {{ consul_tls_prefer_server_cipher_suites | bool | to_json }},
+    {% if auto_encrypt is defined %}
+    "auto_encrypt": {
+        {% if auto_encrypt.enabled | bool and (item.config_version != 'client') | bool %}
+        "allow_tls": true,
+        {% endif %}
+        {% if auto_encrypt.enabled | bool and (item.config_version == 'client') | bool %}
+        "tls": true,
+        {% endif %}
+        {% if auto_encrypt.dns_san is defined %}
+        "dns_san": {{ auto_encrypt.dns_san | list | to_json }},
+        {% endif %}
+        {% if auto_encrypt.ip_san is defined %}
+        "ip_san": {{ auto_encrypt.ip_san | list | to_json }},
+        {% endif %}
+    },
+    {% endif %}
     {% endif %}
 
     {## LAN Join ##}


### PR DESCRIPTION
Add auto_encrypt to support auto TLS between consul servers and clients.
https://learn.hashicorp.com/consul/security-networking/certificates#client-certificate-distribution
https://www.consul.io/docs/agent/options.html#auto_encrypt