### PR TITLE
Disable privilege escalation for local zip install check

### DIFF
--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -94,6 +94,8 @@
   register: is_unzip_installed
   ignore_errors: true
   delegate_to: 127.0.0.1
+  vars:
+    ansible_become: false
 
 - name: Install remotely if unzip is not installed on control host
   set_fact:


### PR DESCRIPTION
If `ansible_become` is set in group or host variables, it takes precedence over task-level `become` settings. Explicitly override it so the local zip install check doesn't require sudo.