### PR TITLE
Fix service deletion in check mode

### DIFF
--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -36,9 +36,13 @@
     services_enabled_files: "{{ services_enabled_windows['files'] }}"
   when: ansible_os_family == 'Windows'
 
+- name: Initialize fact with list of existing configuration files
+  set_fact:
+    list_current_service_config: []
+
 - name: Set fact with list of existing configuration files
   set_fact:
-    list_current_service_config: "{{ list_current_service_config |default([]) + [ item.path ] }}"
+    list_current_service_config: "{{ list_current_service_config + [ item.path ] }}"
   with_items: "{{ services_enabled_files }}"
 
 - name: Set fact with list of service we manage


### PR DESCRIPTION
When installing services on a host for the first time, the role fails in check mode because the list of existing service files is not fetched and thus the `list_current_service_config` fact never gets set because it is in a `with_items` loop whose list of items is empty.

Initializing it to an empty list in a separate task means it is set properly even if the list of files is empty.