### PR TITLE
Guard enable_token_persistence with version check

### DIFF
--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -142,7 +142,9 @@
                     "default_policy": "{{ consul_acl_default_policy }}",
                     "down_policy": "{{ consul_acl_down_policy }}",
                     "token_ttl": "{{ consul_acl_ttl }}",
+                    {% if consul_version is version_compare('1.4.3', '>=') %}
                     "enable_token_persistence": {{ consul_acl_token_persistence | bool | to_json}},
+                    {% endif %}
                     "tokens": {
                         {% if consul_acl_token | trim != '' %}
                         "default": "{{ consul_acl_token }}",
@@ -221,7 +223,9 @@
                 "default_policy": "{{ consul_acl_default_policy }}",
                 "down_policy": "{{ consul_acl_down_policy }}",
                 "token_ttl": "{{ consul_acl_ttl }}",
+                {% if consul_version is version_compare('1.4.3', '>=') %}
                 "enable_token_persistence": {{ consul_acl_token_persistence | bool | to_json}},
+                {% endif %}
                 "tokens": {
                     {% if consul_acl_token | trim != '' %}
                     "default": "{{ consul_acl_token }}",


### PR DESCRIPTION
The `enable_token_persistence` setting was added in Consul 1.4.3.