### PR TITLE
Consul installation from repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,13 +33,14 @@ consul_checksum_file_url: "https://releases.hashicorp.com/consul/{{ consul_versi
 ### Install Method
 consul_install_remotely: false
 consul_install_upgrade: false
+consul_install_from_repo: false
 
 ### Paths
 consul_bin_path: "/usr/local/bin"
 consul_config_path: "/etc/consul"
-consul_configd_path: "{{ consul_config_path }}/consul.d"
+consul_configd_path: "/etc/consul.d"
 consul_bootstrap_state: "{{ consul_config_path }}/.consul_bootstrapped"
-consul_data_path: "/var/consul"
+consul_data_path: "/opt/consul"
 consul_log_path: "{{ lookup('env','CONSUL_LOG_PATH') | default('/var/log/consul', true) }}"
 consul_log_file: "{{ lookup('env','CONSUL_LOG_FILE') | default('consul.log', true) }}"
 consul_run_path: "/run/consul"
@@ -49,7 +50,7 @@ consul_binary: "{{ consul_bin_path }}/consul"
 consul_manage_user: true
 consul_user: "consul"
 consul_manage_group: true
-consul_group: "bin"
+consul_group: "consul"
 consul_systemd_restart_sec: 42
 consul_systemd_limit_nofile: 65536
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -26,3 +26,7 @@
 
 - name: start snapshot
   import_tasks: start_snapshot.yml
+
+- name: systemctl daemon-reload
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/tasks/dirs.yml
+++ b/tasks/dirs.yml
@@ -21,6 +21,7 @@
       owner: "{{ consul_user }}"
       group: "{{ consul_group }}"
       mode: 0750
+    when: not consul_install_from_repo | bool
 
   when: ansible_os_family != 'Windows'
 
@@ -56,7 +57,9 @@
     state: directory
     owner: root
     mode: 0755
-  when: ansible_os_family != 'Windows'
+  when:
+    - ansible_os_family != 'Windows'
+    - not consul_install_from_repo | bool
 
 - name: Create directories on Windows
   win_file:

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -1,0 +1,105 @@
+---
+# File: install_linux_repo.yml - package installation tasks for Consul
+
+- name: Install OS packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ consul_os_packages }}"
+  tags: installation
+
+- name: Populate service facts
+  service_facts:
+
+- name: Gather the package facts
+  package_facts:
+    manager: auto
+
+- name: Clean up previous consul data
+  block:
+    - name: Stop service consul, if running
+      systemd:
+        name: consul
+        state: stopped
+      when: ansible_facts.services['consul.service'] is defined
+
+    - name: Remove consul systemd unit file from previous installation
+      file:
+        path: /usr/lib/systemd/system/consul.service
+        state: absent
+      notify: systemctl daemon-reload
+
+    - name: Remove the user 'consul'
+      user:
+        name: consul
+        state: absent
+        remove: yes
+
+  when:
+    - "ansible_distribution|lower == 'redhat' or ansible_distribution|lower == 'centos' or \
+        ansible_distribution|lower == 'fedora' or ansible_distribution|lower == 'amazon' or \
+        ansible_distribution|lower == 'debian' or ansible_distribution|lower == 'ubuntu'"
+    - "'consul' not in ansible_facts.packages"
+
+- name: Install repository
+  block:
+    - name: Add Redhat/CentOS/Fedora/Amazon Linux repository
+      command: "yum-config-manager --add-repo {{ consul_repo_url }}"
+      args:
+        creates: /etc/yum.repos.d/hashicorp.repo
+      when: "ansible_distribution|lower == 'redhat' or ansible_distribution|lower == 'centos' or \
+            ansible_distribution|lower == 'fedora' or ansible_distribution|lower == 'amazon'"
+
+
+    - name: Add an Apt signing key, uses whichever key is at the URL
+      apt_key:
+        url: https://apt.releases.hashicorp.com/gpg
+        state: present
+      when: ansible_distribution|lower == 'debian' or ansible_distribution|lower == 'ubuntu'
+
+    - name: Add Debian/Ubuntu Linux repository
+      apt_repository:
+        repo: "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+        state: present
+        update_cache: true
+      when: ansible_distribution|lower == 'debian' or ansible_distribution|lower == 'ubuntu'
+
+- name: Install consul package
+  package:
+    name: "consul-{{ consul_version }}"
+    state: present
+
+- name: Create a directory /etc/systemd/system/consul.service.d
+  file:
+    path: /etc/systemd/system/consul.service.d
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+  register: systemd_override
+
+
+- name: Override systemd service params
+  template:
+    src: consul_systemd_service.override.j2
+    dest: /etc/systemd/system/consul.service.d/override.conf
+    owner: root
+    group: root
+    mode: 0644
+  register: systemd_override
+  notify:
+    - systemctl daemon-reload
+    - restart consul
+  when:
+    - ansible_service_mgr == "systemd"
+    - not ansible_os_family == "FreeBSD"
+    - not ansible_os_family == "Solaris"
+    - consul_install_from_repo | bool
+
+- name: Flush handlers
+  meta: flush_handlers
+
+- name: As, this role work with json conf file only - delete file /etc/consul.d/consul.hcl
+  file:
+    path: /etc/consul.d/consul.hcl
+    state: absent

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -29,6 +29,11 @@
 - name: Include user and group settings
   import_tasks: user_group.yml
 
+- name: Install OS packages and consul - from the repository
+  include_tasks: install_linux_repo.yml
+  when:
+    - consul_install_from_repo | bool
+
 - name: Include directory settings
   import_tasks: dirs.yml
 
@@ -46,12 +51,14 @@
   when:
     - consul_install_binary | bool
     - not consul_install_remotely | bool
+    - not consul_install_from_repo | bool
 
 - name: Install OS packages and consul - remotely
   include_tasks: install_remote.yml
   when:
     - consul_install_binary | bool
     - consul_install_remotely | bool
+    - not consul_install_from_repo | bool
 
 # XXX: Individual gossip tasks are deprecated and need to be removed
 # - include_tasks: ../tasks/encrypt_gossip.yml
@@ -198,6 +205,7 @@
     - ansible_service_mgr == "systemd"
     - not ansible_os_family == "FreeBSD"
     - not ansible_os_family == "Solaris"
+    - not consul_install_from_repo | bool
 
 - name: Reload systemd
   systemd:

--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -8,6 +8,7 @@
     state: present
   when:
     - consul_manage_group | bool
+    - not consul_install_from_repo | bool
 
 # Add user
 - name: Add Consul user
@@ -18,3 +19,4 @@
     system: true
   when:
     - consul_manage_user | bool
+    - not consul_install_from_repo | bool

--- a/templates/consul_systemd_service.override.j2
+++ b/templates/consul_systemd_service.override.j2
@@ -1,0 +1,10 @@
+# WARNING!!! Ansible managed.
+
+[Unit]
+ConditionFileNotEmpty=
+ConditionFileNotEmpty={{ consul_config_path }}/config.json
+
+[Service]
+ExecStart=
+ExecStart=/usr/bin/consul agent -config-file={{ consul_config_path }}/config.json -config-dir={{ consul_configd_path }}
+

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -4,3 +4,8 @@ consul_os_packages:
   - git
   - unzip
 consul_syslog_enable: false
+
+consul_os_prepare_packages:
+  - yum-utils
+
+consul_repo_url: https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,3 +3,5 @@
 
 consul_os_packages:
   - unzip
+
+consul_os_prepare_packages: []

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -12,3 +12,12 @@ consul_os_packages:
       python3-libselinux\
     {% endif %}"
   - unzip
+
+consul_os_prepare_packages:
+  - yum-utils
+
+consul_repo_url: "{% if ( ansible_distribution  == 'Fedora') %}\
+      https://rpm.releases.hashicorp.com/fedora/hashicorp.repo\
+    {% else %}\
+      https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo\
+    {% endif %}"


### PR DESCRIPTION
This PR add possibility to install consul from operating system repository, as described here for Linux https://www.consul.io/downloads

To install consul from repository you need to define this variable:
```
consul_install_from_repo: true
```

Changes:
1. consul_configd_path to `/etc/consul.d`, as this is consul documented default directory for services
2. consul_group to `consul`. Reason - should be synced with official configuration in consul repository packages
2. consul_data_path to `/opt/consul`. Reason - should be synced with official configuration in consul repository packages

Supported installation of Consul from repositories for next operating systems:
- CentOS/RedHat/Fedora
- Debian/Ubuntu
- Amazon

Tested on CentOS.