### PR TITLE
distro: add support for Flatcar Linux

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,7 @@ consul_manage_group: true
 consul_group: "bin"
 consul_systemd_restart_sec: 42
 consul_systemd_limit_nofile: 65536
+consul_systemd_unit_path: "/lib/systemd/system"
 
 ### Log user, group, facility
 syslog_user: "{{ lookup('env','SYSLOG_USER') | default('root', true) }}"

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -1,11 +1,27 @@
 ---
 # File: asserts.yml - Asserts for this playbook
 
+- name: Define supported *nix distributions
+  set_fact:
+    _consul_nix_distros:
+      - 'RedHat'
+      - 'CentOS'
+      - 'OracleLinux'
+      - 'Fedora'
+      - 'Debian'
+      - 'FreeBSD'
+      - 'SmartOS'
+      - 'Ubuntu'
+      - 'Archlinux'
+      - 'Alpine'
+      - 'Amazon'
+      - 'Flatcar'
+
 - name: Check distribution compatibility
   fail:
     msg: "{{ ansible_distribution }} is not currently supported by this role."
   when:
-    - ansible_distribution not in ['RedHat', 'CentOS', 'OracleLinux', 'Fedora', 'Debian', 'FreeBSD', 'SmartOS', 'Ubuntu', 'Archlinux', 'Alpine', 'Amazon']
+    - ansible_distribution not in _consul_nix_distros
     - ansible_os_family != 'Windows'
 
 - name: Check CentOS, Red Hat or Oracle Linux version

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -188,7 +188,7 @@
 - name: Create systemd script
   template:
     src: consul_systemd.service.j2
-    dest: /lib/systemd/system/consul.service
+    dest: "{{ consul_systemd_unit_path }}/consul.service"
     owner: root
     group: root
     mode: 0644

--- a/vars/Flatcar.yml
+++ b/vars/Flatcar.yml
@@ -1,0 +1,6 @@
+---
+# File: Flatcar.yml - Flatcar variables for Consul
+
+consul_os_packages: []
+
+consul_systemd_unit_path: "/etc/systemd/system"


### PR DESCRIPTION
 - make systemd unit path configurable as
   Flatcar Linux /lib/systemd/system is read-only.