### PR TITLE
Removed redundant `consul_src_def` and add individual paths for certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,24 +543,6 @@ Notice that the dict object has to use precisely the names stated in the documen
     TLS files on your own
 - Default value: true
 
-### `consul_tls_ca_src_dir`
-
-- User-specified source directory for CA files
-  - Override with `CONSUL_TLS_CA_SRC_DIR` environment variable
-- Default value: `{{ role_path }}/files`
-
-### `consul_tls_cert_src_dir`
-
-- User-specified source directory for cert files
-  - Override with `CONSUL_TLS_CERT_SRC_DIR` environment variable
-- Default value: `{{ role_path }}/files`
-
-### `consul_tls_key_src_dir`
-
-- User-specified source directory for key files
-  - Override with `CONSUL_TLS_KEY_SRC_DIR` environment variable
-- Default value: `{{ role_path }}/files`
-
 ### `consul_tls_dir`
 
 - Target directory for TLS files

--- a/README.md
+++ b/README.md
@@ -543,10 +543,22 @@ Notice that the dict object has to use precisely the names stated in the documen
     TLS files on your own
 - Default value: true
 
-### `consul_tls_src_files`
+### `consul_tls_ca_src_dir`
 
-- User-specified source directory for TLS files
-  - Override with `CONSUL_TLS_SRC_FILES` environment variable
+- User-specified source directory for CA files
+  - Override with `CONSUL_TLS_CA_SRC_DIR` environment variable
+- Default value: `{{ role_path }}/files`
+
+### `consul_tls_cert_src_dir`
+
+- User-specified source directory for cert files
+  - Override with `CONSUL_TLS_CERT_SRC_DIR` environment variable
+- Default value: `{{ role_path }}/files`
+
+### `consul_tls_key_src_dir`
+
+- User-specified source directory for key files
+  - Override with `CONSUL_TLS_KEY_SRC_DIR` environment variable
 - Default value: `{{ role_path }}/files`
 
 ### `consul_tls_dir`

--- a/README.md
+++ b/README.md
@@ -536,12 +536,6 @@ Notice that the dict object has to use precisely the names stated in the documen
   - Override with `CONSUL_ACL_TLS_ENABLE` environment variable
 - Default value: false
 
-### `consul_src_def`
-
-- Default source directory for TLS files
-  - Override with `CONSUL_ACL_TLS_ENABLE` environment variable
-- Default value: `{{ role_path }}/files`
-
 ### `consul_tls_copy_keys`
 
 - Enables or disables the management of the TLS files

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -194,7 +194,9 @@ consul_disable_keyring_file: "{{ lookup('env','CONSUL_DISABLE_KEYRING_FILE') | d
 
 ## TLS
 consul_tls_enable: "{{ lookup('env','CONSUL_TLS_ENABLE') | default(false, true) }}"
-consul_tls_src_files: "{{ lookup('env','CONSUL_TLS_SRC_FILES') | default(role_path+'/files', true) }}"
+consul_tls_ca_src_dir: "{{ lookup('env','CONSUL_TLS_CA_SRC_DIR') | default(role_path+'/files', true) }}"
+consul_tls_cert_src_dir: "{{ lookup('env','CONSUL_TLS_CERT_SRC_DIR') | default(role_path+'/files', true) }}"
+consul_tls_key_src_dir: "{{ lookup('env','CONSUL_TLS_KEY_SRC_DIR') | default(role_path+'/files', true) }}"
 consul_tls_dir: "{{ lookup('env','CONSUL_TLS_DIR') | default('/etc/consul/ssl', true) }}"
 consul_tls_ca_crt: "{{ lookup('env','CONSUL_TLS_CA_CRT') | default('ca.crt', true) }}"
 consul_tls_server_crt: "{{ lookup('env','CONSUL_SERVER_CRT') | default('server.crt', true) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -194,9 +194,6 @@ consul_disable_keyring_file: "{{ lookup('env','CONSUL_DISABLE_KEYRING_FILE') | d
 
 ## TLS
 consul_tls_enable: "{{ lookup('env','CONSUL_TLS_ENABLE') | default(false, true) }}"
-consul_tls_ca_src_dir: "{{ lookup('env','CONSUL_TLS_CA_SRC_DIR') | default(role_path+'/files', true) }}"
-consul_tls_cert_src_dir: "{{ lookup('env','CONSUL_TLS_CERT_SRC_DIR') | default(role_path+'/files', true) }}"
-consul_tls_key_src_dir: "{{ lookup('env','CONSUL_TLS_KEY_SRC_DIR') | default(role_path+'/files', true) }}"
 consul_tls_dir: "{{ lookup('env','CONSUL_TLS_DIR') | default('/etc/consul/ssl', true) }}"
 consul_tls_ca_crt: "{{ lookup('env','CONSUL_TLS_CA_CRT') | default('ca.crt', true) }}"
 consul_tls_server_crt: "{{ lookup('env','CONSUL_SERVER_CRT') | default('server.crt', true) }}"

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -13,8 +13,8 @@
     - name: Copy CA certificate
       copy:
         remote_src: "{{ consul_tls_files_remote_src }}"
-        src: "{{ consul_tls_ca_src_dir }}/{{ consul_tls_ca_crt | basename }}"
-        dest: "{{ consul_tls_dir }}/{{ consul_tls_ca_crt }}"
+        src: "{{ consul_tls_ca_crt }}"
+        dest: "{{ consul_tls_dir }}/{{ consul_tls_ca_crt | basename }}"
         owner: "{{ consul_user }}"
         group: "{{ consul_group }}"
         mode: 0644
@@ -23,8 +23,8 @@
     - name: Copy server certificate
       copy:
         remote_src: "{{ consul_tls_files_remote_src }}"
-        src: "{{ consul_tls_cert_src_dir }}/{{ consul_tls_server_crt | basename }}"
-        dest: "{{ consul_tls_dir }}/{{ consul_tls_server_crt }}"
+        src: "{{ consul_tls_server_crt }}"
+        dest: "{{ consul_tls_dir }}/{{ consul_tls_server_crt | basename }}"
         owner: "{{ consul_user }}"
         group: "{{ consul_group }}"
         mode: 0644
@@ -33,8 +33,8 @@
     - name: Copy server key
       copy:
         remote_src: "{{ consul_tls_files_remote_src }}"
-        src: "{{ consul_tls_key_src_dir }}/{{ consul_tls_server_key | basename }}"
-        dest: "{{ consul_tls_dir }}/{{ consul_tls_server_key }}"
+        src: "{{ consul_tls_server_key }}"
+        dest: "{{ consul_tls_dir }}/{{ consul_tls_server_key | basename }}"
         owner: "{{ consul_user }}"
         group: "{{ consul_group }}"
         mode: 0600

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -13,7 +13,7 @@
     - name: Copy CA certificate
       copy:
         remote_src: "{{ consul_tls_files_remote_src }}"
-        src: "{{ consul_tls_src_files }}/{{ consul_tls_ca_crt | basename }}"
+        src: "{{ consul_tls_ca_src_dir }}/{{ consul_tls_ca_crt | basename }}"
         dest: "{{ consul_tls_dir }}/{{ consul_tls_ca_crt }}"
         owner: "{{ consul_user }}"
         group: "{{ consul_group }}"
@@ -23,7 +23,7 @@
     - name: Copy server certificate
       copy:
         remote_src: "{{ consul_tls_files_remote_src }}"
-        src: "{{ consul_tls_src_files }}/{{ consul_tls_server_crt | basename }}"
+        src: "{{ consul_tls_cert_src_dir }}/{{ consul_tls_server_crt | basename }}"
         dest: "{{ consul_tls_dir }}/{{ consul_tls_server_crt }}"
         owner: "{{ consul_user }}"
         group: "{{ consul_group }}"
@@ -33,7 +33,7 @@
     - name: Copy server key
       copy:
         remote_src: "{{ consul_tls_files_remote_src }}"
-        src: "{{ consul_tls_src_files }}/{{ consul_tls_server_key | basename }}"
+        src: "{{ consul_tls_key_src_dir }}/{{ consul_tls_server_key | basename }}"
         dest: "{{ consul_tls_dir }}/{{ consul_tls_server_key }}"
         owner: "{{ consul_user }}"
         group: "{{ consul_group }}"


### PR DESCRIPTION
The title says it all. That variable is not used anywhere in the code.

Removed `consul_tls_src_files` as it can be embedded into individual cert paths.