### PR TITLE
install_via_repo: Fix shell expansion using ansible fact and fix versions for apt

### DIFF
--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -66,7 +66,7 @@
 
 - name: Install consul package
   package:
-    name: "consul-{{ consul_version }}"
+    name: "consul{{ '=' if ansible_pkg_mgr == 'apt' else '-' }}{{ consul_version }}"
     state: present
 
 - name: Create a directory /etc/systemd/system/consul.service.d

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -59,7 +59,7 @@
 
     - name: Add Debian/Ubuntu Linux repository
       apt_repository:
-        repo: "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+        repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
         state: present
         update_cache: true
       when: ansible_distribution|lower == 'debian' or ansible_distribution|lower == 'ubuntu'


### PR DESCRIPTION
The previous apt repo line was using a shell expansion which will not work inside the apt_repository module. Replacing it with a Fact.