### PR TITLE
Fix config templating on Ansible 5

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -6,7 +6,7 @@
     dest: "{{ item.dest }}"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    content: "{{ lookup('template', 'templates/config.json.j2') | to_nice_json }}"
+    content: "{{ lookup('template', 'templates/config.json.j2', convert_data=True) | to_nice_json }}"
     mode: 0600
   with_items:
     - dest: "{{ consul_config_path }}/config.json"
@@ -31,7 +31,7 @@
     dest: "{{ consul_configd_path }}/50custom.json"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    content: "{{ lookup('template', 'templates/configd_50custom.json.j2') | to_nice_json }}"
+    content: "{{ lookup('template', 'templates/configd_50custom.json.j2', convert_data=True) | to_nice_json }}"
     mode: 0600
   when:
     - consul_config_custom is defined

--- a/tasks/config_windows.yml
+++ b/tasks/config_windows.yml
@@ -4,7 +4,7 @@
 - name: Create configuration
   win_copy:
     dest: "{{ item.dest }}"
-    content: "{{ lookup('template', 'templates/config.json.j2') | to_nice_json }}"
+    content: "{{ lookup('template', 'templates/config.json.j2', convert_data=True) | to_nice_json }}"
   with_items:
     - dest: "{{ consul_config_path }}/config.json"
       config_version: "{{ consul_node_role }}"
@@ -26,7 +26,7 @@
 - name: Create custom configuration
   win_copy:
     dest: "{{ consul_configd_path }}/50custom.json"
-    content: "{{ lookup('template', 'templates/configd_50custom.json.j2') | to_nice_json }}"
+    content: "{{ lookup('template', 'templates/configd_50custom.json.j2', convert_data=True) | to_nice_json }}"
   when:
     - consul_config_custom is defined
   notify:


### PR DESCRIPTION
In Ansible 5, lookup function produces string output (new default? I couldn't find any confirmation about this). Applying to_nice_json provides a double encapsulated JSON output, which is invalid for Consul.

I'd like some feedback as I have only tested this on Linux so far with Ansible 5. Not sure if this is backwards compatible or maybe Ansible introduced a breaking change unindentionally.

Some more info here: https://github.com/ansible/ansible/issues/76443