### PR TITLE
Mention that by default acl_datacenter name is equal to datacenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Notice that the dict object has to use precisely the names stated in the documen
 
 - ACL authoritative datacenter name
   - Override with `CONSUL_ACL_DATACENTER` environment variable
-- Default value: dc1
+- Default value: `{{ consul_datacenter }}` (`dc1`)
 
 ### `consul_acl_down_policy`
 


### PR DESCRIPTION
Mention that by default the value of `consul_acl_datacenter` is equal to the value of `consul_datacenter` so you only need to modify `consul_datacenter` if you want to use the same value for both.