### PR TITLE
Support setting consul_version to latest for latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Many role variables can also take their values from environment variables as wel
 ### `consul_version`
 
 - Version to install
+- Set value as `latest` for the latest available version of consul
 - Default value: 1.8.7
 
 ### `consul_architecture_map`

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 # File: main.yml - Main tasks for Consul
+- name: Looking up latest version of Consul
+  set_fact:
+    consul_version: "{{ (lookup('url', 'https://api.github.com/repos/hashicorp/consul/releases/latest', split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
+  when: 'consul_version == "latest"'
 
 - name: Install python dependencies
   when:


### PR DESCRIPTION
Support setting `consul_version` to `latest` for the latest version of consul.
Looks up the latest available version of consul from the releases in hashicorp's consul github repo.

I didn't want to set the default value of `consul_version` to `latest`  to avoid the role breaking with newer versions as I assumed the ansible role has been tested against the currently specified default.