### PR TITLE
Re-add documentation for consul_install_dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Many role variables can also take their values from environment variables as wel
 - Operating system name in lowercase representation
 - Default value: `{{ ansible_os_family | lower }}`
 
+### `consul_install_dependencies`
+
+- Install python and package dependencies required for the role functions.
+- Default value: true
+
 ### `consul_zip_url`
 
 - Consul archive file download URL


### PR DESCRIPTION
Re-adds documentation for the `consul_install_dependencies` variable.

I suppose this was removed by accident in  in https://github.com/ansible-community/ansible-consul/commit/ad475185c4b6269a69f20153bd2438e3f8b70bbe when @brianshumate removed local unzip installation, however the key is also used for installing pip dependencies locally which should be a optional step and should thus be documented.

That being said, I'm not really fond of having this value set to true by default, the python dependencies should be detected and the install should only run when needed or this local pip task could even be dropped.