### PR TITLE
fixes #458

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,11 @@ consul3.node.consul.  0 IN  A 10.1.42.230
 - Enable Consul Connect feature
 - Default value: false
 
+### `consul_cleanup_ignore_files`
+
+- List of files to ignore during cleanup steps
+- Default value: *[{{ consul_configd_path }}/consul.env]*
+
 ### iptables DNS Forwarding Support
 
 This role can also use iptables instead of Dnsmasq for forwarding DNS queries to Consul. You can enable it like this:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -257,3 +257,7 @@ consul_connect_enabled: false
 
 # system limits
 consul_limits: {}
+
+# files clean up
+consul_cleanup_ignore_files:
+  - '{{ consul_configd_path }}/consul.env'

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -51,7 +51,7 @@
   file:
     path: "{{ item }}"
     state: absent
-  when: ansible_os_family != 'Windows' and item not in managed_files
+  when: ansible_os_family != 'Windows' and item not in managed_files and item not in consul_cleanup_ignore_files
   with_items: "{{ list_current_service_config }}"
   ignore_errors: "{{ ansible_check_mode }}"
   notify:
@@ -61,7 +61,7 @@
   win_file:
     path: "{{ item }}"
     state: absent
-  when: ansible_os_family == 'Windows' and item not in managed_files
+  when: ansible_os_family == 'Windows' and item not in managed_files and item not in consul_cleanup_ignore_files
   with_items: "{{ list_current_service_config }}"
   ignore_errors: "{{ ansible_check_mode }}"
   notify:


### PR DESCRIPTION
When installing consul from official packages (deb, rpm...), systemd
service file expect to have an environment file to load. This commit
prevent the cleaning operation to remove expected files.

Signed-off-by: Wilfried Roset <wilfriedroset@users.noreply.github.com>