### PR TITLE
Few Improvements to repo install

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -28,5 +28,6 @@
   import_tasks: start_snapshot.yml
 
 - name: systemctl daemon-reload
-  ansible.builtin.systemd:
+  systemd:
     daemon_reload: yes
+  become: true

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -3,8 +3,10 @@
 
 - name: Install OS packages
   package:
-    name: "{{ consul_os_packages }}"
+    name: "{{ consul_repo_prerequisites }}"
     state: present
+  become: true
+  when: (consul_os_repo_prerequisites)
   tags: installation
 
 - name: Populate service facts

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -51,13 +51,13 @@
 
     - name: Add an Apt signing key, uses whichever key is at the URL
       apt_key:
-        url: https://apt.releases.hashicorp.com/gpg
+        url: "{{ consul_repo_url }}/gpg"
         state: present
       when: "ansible_os_family|lower == 'debian'"
 
     - name: Add Debian/Ubuntu Linux repository
       apt_repository:
-        repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+        repo: "deb [arch=amd64] {{ consul_repo_url }} {{ ansible_distribution_release }} main"
         state: present
         update_cache: true
       when: "ansible_os_family|lower == 'debian'"

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -47,27 +47,29 @@
       command: "yum-config-manager --add-repo {{ consul_repo_url }}"
       args:
         creates: /etc/yum.repos.d/hashicorp.repo
-      when: "ansible_distribution|lower == 'redhat' or ansible_distribution|lower == 'centos' or \
-            ansible_distribution|lower == 'fedora' or ansible_distribution|lower == 'amazon'"
-
+      when: "ansible_os_family|lower == 'redhat'"
 
     - name: Add an Apt signing key, uses whichever key is at the URL
       apt_key:
         url: https://apt.releases.hashicorp.com/gpg
         state: present
-      when: ansible_distribution|lower == 'debian' or ansible_distribution|lower == 'ubuntu'
+      when: "ansible_os_family|lower == 'debian'"
 
     - name: Add Debian/Ubuntu Linux repository
       apt_repository:
         repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
         state: present
         update_cache: true
-      when: ansible_distribution|lower == 'debian' or ansible_distribution|lower == 'ubuntu'
+      when: "ansible_os_family|lower == 'debian'"
+
+  when: "ansible_os_family|lower in [ 'debian', 'redhat' ]"
+  become: true
 
 - name: Install consul package
   package:
     name: "consul{{ '=' if ansible_pkg_mgr == 'apt' else '-' }}{{ consul_version }}"
     state: present
+  become: true
 
 - name: Create a directory /etc/systemd/system/consul.service.d
   file:
@@ -77,7 +79,8 @@
     owner: root
     group: root
   register: systemd_override
-
+  become: true
+  when: ansible_service_mgr == "systemd"
 
 - name: Override systemd service params
   template:
@@ -87,13 +90,12 @@
     group: root
     mode: 0644
   register: systemd_override
+  become: true
   notify:
     - systemctl daemon-reload
     - restart consul
   when:
     - ansible_service_mgr == "systemd"
-    - not ansible_os_family == "FreeBSD"
-    - not ansible_os_family == "Solaris"
     - consul_install_from_repo | bool
 
 - name: Flush handlers
@@ -103,3 +105,4 @@
   file:
     path: /etc/consul.d/consul.hcl
     state: absent
+  become: true

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -19,16 +19,18 @@
 - name: Clean up previous consul data
   block:
     - name: Stop service consul, if running
-      systemd:
+      service:
         name: consul
         state: stopped
-      when: ansible_facts.services['consul.service'] is defined
+      when: ansible_facts.services | join is match('.*consul.*')
 
-    - name: Remove consul systemd unit file from previous installation
+    - name: Remove consul service unit files from previous installation
       file:
-        path: /usr/lib/systemd/system/consul.service
+        path: "{{ item }}"
         state: absent
-      notify: systemctl daemon-reload
+      loop:
+        - /usr/lib/systemd/system/consul.service
+        - /etc/init.d/consul
 
     - name: Remove the user 'consul'
       user:
@@ -36,11 +38,8 @@
         state: absent
         remove: yes
 
-  when:
-    - "ansible_distribution|lower == 'redhat' or ansible_distribution|lower == 'centos' or \
-        ansible_distribution|lower == 'fedora' or ansible_distribution|lower == 'amazon' or \
-        ansible_distribution|lower == 'debian' or ansible_distribution|lower == 'ubuntu'"
-    - "'consul' not in ansible_facts.packages"
+  when: "'consul' not in ansible_facts.packages"
+  become: true
 
 - name: Install repository
   block:

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,11 +1,12 @@
 ---
-# File: Archlinux.yml - Archlinux variables for Consul
+# File: Amazon.yml - Amazonlinux variables for Consul
 consul_os_packages:
   - git
   - unzip
+
 consul_syslog_enable: false
 
-consul_os_prepare_packages:
+consul_repo_prerequisites:
   - yum-utils
 
 consul_repo_url: https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,3 +6,5 @@ consul_os_packages:
 
 consul_repo_prerequisites:
   - gpg
+
+consul_repo_url: "https://apt.releases.hashicorp.com"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,4 +4,5 @@
 consul_os_packages:
   - unzip
 
-consul_repo_prerequisites: []
+consul_repo_prerequisites:
+  - gpg

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,4 +4,4 @@
 consul_os_packages:
   - unzip
 
-consul_os_prepare_packages: []
+consul_repo_prerequisites: []

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -13,7 +13,7 @@ consul_os_packages:
     {% endif %}"
   - unzip
 
-consul_os_prepare_packages:
+consul_repo_prerequisites:
   - yum-utils
 
 consul_repo_url: "{% if ( ansible_distribution  == 'Fedora') %}\


### PR DESCRIPTION
Few improvements to repo install:

- Corrected the repo install prerequisites - the list of packages was the same as used for the archive install and the specific list for the repo install was unused: https://github.com/ansible-community/ansible-consul/issues/436#issuecomment-1000449682
- Made cleanup tasks compatible with other init systems than systemd.
- Simplified the conditionals.
- Added `become` to the tasks that require it
- Specified the apt repo as a variable rather than having it hard-coded (so that it can me overwritten when mirroring the repo internally)