### PR TITLE
Add main configuration files to managed_files list

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -26,6 +26,16 @@
   notify:
     - restart consul
 
+- name: Set fact list with managed configuration file
+  set_fact:
+    managed_files: "{{ managed_files | d([]) }} + {{ configs }}"
+  vars:
+    configs:
+      - "{{ consul_config_path }}/config.json"
+      - "{{ consul_config_path }}/bootstrap.json"
+      - "{{ consul_config_path }}/server.json"
+      - "{{ consul_config_path }}/client.json"
+
 - name: Create custom configuration
   copy:
     dest: "{{ consul_configd_path }}/50custom.json"


### PR DESCRIPTION
The difference between `consul_config_path` and `consul_configd_path` was not clear to me at a first glance. That's why I have set them to the same value. This led me to the state, when all config files are removed during deployment. Because in [services.yml](./tasks/services.yml) all files within `consul_configd_path` which are not present in `managed_files` list are removed.

My change will save configuration files from accidential remove by other task in this role. It seems rather sane to add thses files to `managed_files` list as well.
