### PR TITLE
config: fix deprecated usage of ui field.

### DIFF
--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -295,5 +295,11 @@
     {% endif %}
 
     {## UI ##}
+    {% if consul_version is version_compare('1.9.0', '>=') %}
+    "ui_config": {
+        "enabled": {{ consul_ui | bool | to_json }}
+    }
+    {% else %}
     "ui": {{ consul_ui | bool | to_json }}
+    {% endif %}
 }


### PR DESCRIPTION
 - use `ui_config` if consul version is 1.9.0 or
   newer.
   See https://www.consul.io/docs/agent/options#ui-1