### PR TITLE
Fix directory /usr/local/etc/dnsmasq.d not found

### DIFF
--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -37,7 +37,7 @@
     mode: 0644
   become: true
   notify: restart dnsmasq
-  when: item.when
+  when: "{{ item.when }}"
   tags: dnsmasq
   loop:
     - { dest: '/etc/dnsmasq.d/10-consul', group: 'root', when: ansible_os_family|lower != "freebsd" }


### PR DESCRIPTION
When running with ansible 2.15.5 the item.when is not evaluated and is true, therefore it tries to create both configs files. Resulting in a directory not found error.