### PR TITLE
Exclude Mac from service handler tasks

### DIFF
--- a/handlers/reload_consul_conf.yml
+++ b/handlers/reload_consul_conf.yml
@@ -2,7 +2,7 @@
 # Use SIGHUP to reload most configurations as per https://www.consul.io/docs/agent/options.html
 # Cannot use `consul reload` because it requires the HTTP API to be bound to a non-loopback interface
 
-- name: reload consul configuration on Linux
+- name: reload consul configuration on unix
   command: "pkill --pidfile '{{ consul_run_path }}/consul.pid' --signal SIGHUP"
   when: ansible_os_family != "Windows"
   listen: 'reload consul configuration'

--- a/handlers/restart_consul.yml
+++ b/handlers/restart_consul.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart consul on Linux
+- name: restart consul on unix
   service:
     name: consul
     state: restarted

--- a/handlers/restart_consul.yml
+++ b/handlers/restart_consul.yml
@@ -3,7 +3,9 @@
   service:
     name: consul
     state: restarted
-  when: ansible_os_family != "Windows"
+  when:
+    - ansible_os_family != "Darwin"
+    - ansible_os_family != "Windows"
   listen: 'restart consul'
 
 - name: restart consul on windows

--- a/handlers/restart_rsyslog.yml
+++ b/handlers/restart_rsyslog.yml
@@ -3,5 +3,7 @@
   service:
     name: rsyslog
     state: restarted
-  when: ansible_os_family != "Windows"
+  when:
+    - ansible_os_family != "Darwin"
+    - ansible_os_family != "Windows"
   listen: 'restart rsyslog'

--- a/handlers/start_consul.yml
+++ b/handlers/start_consul.yml
@@ -1,5 +1,5 @@
 ---
-- name: start consul on Linux
+- name: start consul on unix
   service:
     name: consul
     state: started

--- a/handlers/start_consul.yml
+++ b/handlers/start_consul.yml
@@ -3,7 +3,9 @@
   service:
     name: consul
     state: started
-  when: ansible_os_family != "Windows"
+  when:
+    - ansible_os_family != "Darwin"
+    - ansible_os_family != "Windows"
   listen: 'start consul'
 
 - name: start consul on windows

--- a/handlers/start_snapshot.yml
+++ b/handlers/start_snapshot.yml
@@ -1,5 +1,5 @@
 ---
-- name: start consul snapshot on linux
+- name: start consul snapshot on unix
   service:
     name: consul_snapshot
     state: started

--- a/handlers/start_snapshot.yml
+++ b/handlers/start_snapshot.yml
@@ -4,5 +4,7 @@
     name: consul_snapshot
     state: started
     enabled: true
-  when: ansible_os_family != "Windows"
+  when:
+    - ansible_os_family != "Darwin"
+    - ansible_os_family != "Windows"
   listen: 'start snapshot'


### PR DESCRIPTION
Mac isn't supported by this role yet, but consul itself does and some
of the task files in this role are useful to configure consul on that
platform. However, some of those tasks may invoke handlers that will
invariably fail on Mac since it doesn't support the service module.

---

Fixes #476.
