### PR TITLE
Use "is failed" instead of comparing result code

### DIFF
--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -125,4 +125,4 @@
   set_fact:
     consul_install_remotely: true
   when:
-    - is_unzip_installed.rc == 1
+    - is_unzip_installed is failed


### PR DESCRIPTION
This syntax is a bit more robust and can handle the cases where the task
fails with return codes other than 1. It should also handle the
following error which can occur if the task fails for other reasons:

```
The conditional check 'is_unzip_installed.rc == 1' failed. The error
was: error while evaluating conditional (is_unzip_installed.rc == 1):
'dict object' has no attribute 'rc'
```