### PR TITLE
Retry restarting service on Windows

### DIFF
--- a/handlers/restart_consul.yml
+++ b/handlers/restart_consul.yml
@@ -11,4 +11,8 @@
     name: consul
     state: restarted
   when: ansible_os_family == "Windows"
+  register: windows_service_started
+  retries: 3
+  delay: 1
+  until: windows_service_started is succeeded
   listen: 'restart consul'


### PR DESCRIPTION
In some cases, Windows' ability to restart a service is faster than
consul's ability to shut down cleanly. In such cases, these lines can be
seen in the consul log:

```
[INFO]  agent.client: shutting down client
[ERROR] agent: Error starting agent: error="Failed to start Consul
client: Failed to start lan serf: Failed to create memberlist: Could not
set up network transport: failed to obtain an address: Failed to start
TCP listener on "10.50.0.45" port 8301: listen tcp 10.50.0.45:8301:
bind: Only one usage of each socket address (protocol/network
address/port) is normally permitted."
[INFO]  agent: Exit code: code=1
```

The log timestamps also show that all three messages occur at the exact
same time, indicating that there is likely a race condition here.
Usually, a second retry one second later should provide enough time to
beat the race condition, but for good measure, we'll retry up to three
times just to be safe.