### PR TITLE
Fix undefined variable for repo installs

### DIFF
--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -37,7 +37,7 @@
     mode: 0644
   become: true
   notify: restart dnsmasq
-  when: "{{ item.when }}"
+  when: item.when
   tags: dnsmasq
   loop:
     - { dest: '/etc/dnsmasq.d/10-consul', group: 'root', when: ansible_os_family|lower != "freebsd" }

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -6,7 +6,7 @@
     name: "{{ consul_repo_prerequisites }}"
     state: present
   become: true
-  when: (consul_os_repo_prerequisites)
+  when: (consul_repo_prerequisites)
   tags: installation
 
 - name: Populate service facts


### PR DESCRIPTION
https://github.com/ansible-community/ansible-consul/pull/460 introduced an typo causing repo installations to fail

```
TASK [ansible-consul : Install OS packages] ***********************************************************************************************************************
fatal: [neptune]: FAILED! => {"msg": "The conditional check '(consul_os_repo_prerequisites)' failed. The error was: error while evaluating conditional ((consul_os_repo_prerequisites)): 'consul_os_repo_prerequisites' is undefined\n\nThe error appears to be in '***/.cache/roles/ansible-consul/tasks/install_linux_repo.yml': line 4, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Install OS packages\n  ^ here\n"}
```

Also reported here: https://github.com/ansible-community/ansible-consul/issues/466
