### PR TITLE
Correct dnsmasq loop variable

### DIFF
--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -37,7 +37,7 @@
     mode: 0644
   become: true
   notify: restart dnsmasq
-  when: "{{ item.when }}"
+  when: "{{ dnsmasq_item.when }}"
   tags: dnsmasq
   loop:
     - { dest: '/etc/dnsmasq.d/10-consul', group: 'root', when: ansible_os_family|lower != "freebsd" }


### PR DESCRIPTION
Loop_var was set to "dnsmasq_item", but "item" was still in use in the play, leading to this error : 
`The conditional check '{{ item.when }}' failed. Error while evaluating conditional ({{ item.when }}): 'item' is undefined`