### PR TITLE
Use tls stanza on version >= 1.12

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -207,7 +207,7 @@ consul_tls_verify_incoming_rpc: "{{ lookup('env','CONSUL_TLS_VERIFY_INCOMING_RPC
 consul_tls_verify_incoming_https: "{{ lookup('env','CONSUL_TLS_VERIFY_INCOMING_HTTPS') | default(false, true) }}"
 consul_tls_verify_server_hostname: "{{ lookup('env','CONSUL_TLS_VERIFY_SERVER_HOSTNAME') | default(false, true) }}"
 consul_tls_files_remote_src: false
-consul_tls_min_version: "{{ lookup('env','CONSUL_TLS_MIN_VERSION') | default('tls12', true) }}"
+consul_tls_min_version: "{{ lookup('env','CONSUL_TLS_MIN_VERSION') | default('TLSv1_2', true) }}"
 consul_tls_cipher_suites: ""
 consul_tls_prefer_server_cipher_suites: "{{ lookup('env','CONSUL_TLS_PREFER_SERVER_CIPHER_SUITES') | default('false', true) }}"
 auto_encrypt:

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -90,6 +90,37 @@
     "disable_keyring_file": true,
     {% endif %}
     {% if consul_tls_enable | bool %}
+    {% if consul_version is version_compare('1.12.0', '>=') %}
+    "tls": {
+        "defaults": {
+            "ca_file": "{{ consul_tls_dir }}/{{ consul_tls_ca_crt | basename }}",
+            {% if auto_encrypt is not defined or (auto_encrypt is defined and not auto_encrypt.enabled | bool)
+                or (config_item.config_version != 'client') | bool %}
+            "cert_file": "{{ consul_tls_dir }}/{{ consul_tls_server_crt | basename }}",
+            "key_file": "{{ consul_tls_dir }}/{{ consul_tls_server_key | basename }}",
+            "verify_incoming": {{ consul_tls_verify_incoming | bool | to_json }},
+            {% else %}
+            "verify_incoming": false,
+            {% endif %}
+            "verify_outgoing": {{ consul_tls_verify_outgoing | bool | to_json }},
+            "tls_min_version": "{{ consul_tls_min_version }}",
+            {% if consul_tls_cipher_suites is defined and consul_tls_cipher_suites %}
+            "tls_cipher_suites": "{{ consul_tls_cipher_suites}}",
+            {% endif %}
+        },
+        {% if consul_tls_verify_incoming_rpc is defined or consul_tls_verify_server_hostname is defined %}
+        "internal_rpc": {
+            "verify_incoming": {{consul_tls_verify_incoming_rpc | bool| to_json }},
+            "verify_server_hostname": {{ consul_tls_verify_server_hostname | bool | to_json }},
+        },
+        {% endif %}
+        {% if consul_tls_verify_incoming_https is defined %}
+        "https": {
+            "verify_incoming": {{consul_tls_verify_incoming_https | bool| to_json }},
+        },
+        {% endif %}
+    },
+    {% else %}
     "ca_file": "{{ consul_tls_dir }}/{{ consul_tls_ca_crt | basename }}",
     {% if auto_encrypt is not defined or (auto_encrypt is defined and not auto_encrypt.enabled | bool)
         or (config_item.config_version != 'client') | bool %}
@@ -97,7 +128,7 @@
     "key_file": "{{ consul_tls_dir }}/{{ consul_tls_server_key | basename }}",
     "verify_incoming": {{ consul_tls_verify_incoming | bool | to_json }},
     {% else %}
-    "verify_incoming": false, 
+    "verify_incoming": false,
     {% endif %}
     "verify_outgoing": {{ consul_tls_verify_outgoing | bool | to_json }},
     "verify_incoming_rpc": {{consul_tls_verify_incoming_rpc | bool| to_json }},
@@ -109,6 +140,7 @@
     {% endif %}
     {% if consul_version is version_compare('1.11.0', '<') %}
     "tls_prefer_server_cipher_suites": {{ consul_tls_prefer_server_cipher_suites | bool | to_json }},
+    {% endif %}
     {% endif %}
     {% if auto_encrypt is defined %}
     "auto_encrypt": {


### PR DESCRIPTION
Previous TLS options are deprecated in consul 1.12  https://www.consul.io/docs/agent/config/config-files#tls_deprecated_options

the default version of tls_min_version is also updated following https://www.consul.io/docs/agent/config/config-files#tls_defaults_tls_min_version 

This MR set the config file with new tls stanza 