### PR TITLE
fix ACL info when upgrading an existing cluster

### DIFF
--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -1,18 +1,5 @@
 ---
 # File: acl.yml - ACL tasks for Consul
-
-- name: Lookup at Consul installed version
-  ansible.builtin.command:
-    cmd: consul version -format json
-  changed_when: false
-  register: consul_installed_version_read
-
-- name: Set consul_installed_version
-  set_fact:
-    consul_installed_version: "{{ consul_installed_version_read.stdout | from_json | json_query(query) }}"
-  vars:
-    query: "Version"
-
 - block:
     - name: Read ACL master token from previously boostrapped server
       command: "cat {{ consul_config_path }}/config.json"
@@ -27,15 +14,14 @@
       vars:
         query: "acl.tokens.master"
       no_log: true
-      when: consul_installed_version is version_compare('1.11.0', '<')
 
-    - name: Save acl_master_token from existing configuration
+    - name: Save acl_initial_management from existing configuration if acl_master_token not found
       set_fact:
         consul_acl_master_token: "{{ config_read.stdout | from_json | json_query(query) }}"
       vars:
         query: "acl.tokens.initial_management"
       no_log: true
-      when: consul_installed_version is version_compare('1.11.0', '>=')
+      when: consul_acl_master_token | length == 0
 
   when:
     - bootstrap_state.stat.exists | bool

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -1,6 +1,18 @@
 ---
 # File: acl.yml - ACL tasks for Consul
 
+- name: Lookup at Consul installed version
+  ansible.builtin.command:
+    cmd: consul version -format json
+  changed_when: false
+  register: consul_installed_version_read
+
+- name: Set consul_installed_version
+  set_fact:
+    consul_installed_version: "{{ consul_installed_version_read.stdout | from_json | json_query(query) }}"
+  vars:
+    query: "Version"
+
 - block:
     - name: Read ACL master token from previously boostrapped server
       command: "cat {{ consul_config_path }}/config.json"
@@ -15,6 +27,15 @@
       vars:
         query: "acl.tokens.master"
       no_log: true
+      when: consul_installed_version is version_compare('1.11.0', '<')
+
+    - name: Save acl_master_token from existing configuration
+      set_fact:
+        consul_acl_master_token: "{{ config_read.stdout | from_json | json_query(query) }}"
+      vars:
+        query: "acl.tokens.initial_management"
+      no_log: true
+      when: consul_installed_version is version_compare('1.11.0', '>=')
 
   when:
     - bootstrap_state.stat.exists | bool
@@ -48,21 +69,19 @@
     - consul_node_role == 'server'
 
 - block:
-
-    - name: Read ACL replication token from previously boostrapped server
-      shell: >
-        cat {{ consul_config_path }}/config.json |
-        grep "replication" |
-        sed -E 's/"replication": "(.+)",?/\1/' |
-        sed 's/^ *//;s/ *$//'
+    - name: Read ACL master token from previously boostrapped server
+      command: "cat {{ consul_config_path }}/config.json"
+      register: config_read
+      no_log: true
       changed_when: false
-      check_mode: false
-      register: consul_acl_replication_token_read
       run_once: true
 
     - name: Save acl_replication_token from existing configuration
-      set_fact: consul_acl_replication_token="{{ consul_acl_replication_token_read.stdout }}"
-      ignore_errors: true
+      set_fact:
+        consul_acl_replication_token: "{{ config_read.stdout | from_json | json_query(query) }}"
+      vars:
+        query: "acl.tokens.replication"
+      no_log: true
 
   when:
     - bootstrap_state.stat.exists | bool


### PR DESCRIPTION
Following this commit https://github.com/ansible-community/ansible-consul/commit/b41858efc5a86f145cf47b5f793903505fcd1f79  https://github.com/ansible-community/ansible-consul/pull/499 running the playbook against a Consul > v1.11.0 version won't fetch the existing master token from the config file as the field is now renamed. Therefore the token will be removed from the config file. 

This PR will check both of the value in order to set the token back in the config file if it is defined

I also updated the way we fetch the replication token. It's now done the same way  as the master token which is much more readable and reliable than the `sed` expression