### PR TITLE
Fix role being unable to find package dnsmasq on RHEL8

### DIFF
--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -4,3 +4,4 @@
 consul_os_packages:
   - python3-libselinux
   - unzip
+dnsmasq_package: dnsmasq


### PR DESCRIPTION
This fixes error occurring on Rocky Linux 8. Role was unable to find dnsmasq package.
OS that it wasn't working on:
```
NAME="Rocky Linux"
VERSION="8.6 (Green Obsidian)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="8.6"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Rocky Linux 8.6 (Green Obsidian)"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:rocky:rocky:8:GA"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
ROCKY_SUPPORT_PRODUCT="Rocky Linux"
ROCKY_SUPPORT_PRODUCT_VERSION="8"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8"
```
Error details:
```
- name: Install Dnsmasq package
  ^ here

fatal: [gameserver-fsn-2]: FAILED! => {}

MSG:

The task includes an option with an undefined variable. The error was: 'dnsmasq_package' is undefined
```