### PR TITLE
Support upgrading consul when version changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,13 @@ auto_encrypt:
   ip_san: ["127.0.0.1"]
 ```
 
+### `consul_force_install`
+
+- If true, then always install consul. Otherwise, consul will only be installed either if
+  not present on the host, or if the installed version differs from `consul_version`.
+- The role does not handle the orchestration of a rolling update of servers followed by client nodes
+- Default value: false
+
 ### `consul_install_remotely`
 
 - Whether to download the files for installation directly on the remote hosts

--- a/README.md
+++ b/README.md
@@ -679,13 +679,6 @@ auto_encrypt:
 - This is the only option on Windows as WinRM is somewhat limited in this scope
 - Default value: false
 
-### `consul_install_upgrade`
-
-- Whether to [upgrade consul](https://www.consul.io/docs/upgrading.html) when a new version is specified
-- The role does not handle the orchestration of a rolling update of servers followed by client nodes
-- This option is not available for Windows, yet. (PR welcome)
-- Default value: false
-
 ### `consul_install_from_repo`
 
 - Boolean, whether to install consul from repository as opposed to installing the binary directly.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,7 @@ consul_zip_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/cons
 consul_checksum_file_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version}}_SHA256SUMS"
 
 ### Install Method
+consul_force_install: false
 consul_install_remotely: false
 consul_install_upgrade: false
 consul_install_from_repo: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,6 @@ consul_checksum_file_url: "https://releases.hashicorp.com/consul/{{ consul_versi
 ### Install Method
 consul_force_install: false
 consul_install_remotely: false
-consul_install_upgrade: false
 consul_install_from_repo: false
 
 ### Paths

--- a/handlers/restart_consul.yml
+++ b/handlers/restart_consul.yml
@@ -1,4 +1,11 @@
 ---
+- name: Daemon reload systemd in case the binaries upgraded
+  systemd:
+    daemon_reload: yes
+  become: true
+  when: ansible_service_mgr == "systemd"
+  listen: 'reload systemd daemon'
+
 - name: restart consul on unix
   service:
     name: consul

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -122,16 +122,9 @@
         mode: 0755
       notify:
         - restart consul
+        - reload systemd daemon
       tags: installation
       ignore_errors: "{{ ansible_check_mode }}"
-
-    - name: Daemon reload systemd in case the binaries upgraded
-      systemd:
-        daemon_reload: yes
-      become: true
-      when:
-        - ansible_service_mgr == "systemd"
-        - consul_install_upgrade | bool
   always:
     - name: Cleanup
       file:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,6 +16,13 @@
   tags: installation
   when: ansible_facts['os_family'] == "VMware Photon OS"
 
+- name: Update Alpine Package Manager (APK)
+  apk:
+    update_cache: true
+  run_once: true
+  when: ansible_os_family == "Alpine"
+  delegate_to: 127.0.0.1
+
 - name: Read package checksum file
   stat:
     path: "{{ role_path }}/files/consul_{{ consul_version }}_SHA256SUMS"
@@ -76,13 +83,6 @@
   run_once: true
   delegate_to: 127.0.0.1
   ignore_errors: "{{ ansible_check_mode }}"
-
-- name: Update Alpine Package Manager (APK)
-  apk:
-    update_cache: true
-  run_once: true
-  when: ansible_os_family == "Alpine"
-  delegate_to: 127.0.0.1
 
 - name: Create Temporary Directory for Extraction
   tempfile:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -96,49 +96,51 @@
   run_once: true
   delegate_to: 127.0.0.1
 
-- name: Unarchive Consul package
-  unarchive:
-    src: "{{ role_path }}/files/{{ consul_pkg }}"
-    dest: "{{ install_temp.path }}/"
-    creates: "{{ install_temp.path }}/consul"
-  become: false
-  vars:
-    ansible_become: false
-  tags:
-    - installation
-    - skip_ansible_lint
-  run_once: true
-  delegate_to: 127.0.0.1
-  ignore_errors: "{{ ansible_check_mode }}"
+- name: Unarchive and install Consul
+  block:
+    - name: Unarchive Consul package
+      unarchive:
+        src: "{{ role_path }}/files/{{ consul_pkg }}"
+        dest: "{{ install_temp.path }}/"
+        creates: "{{ install_temp.path }}/consul"
+      become: false
+      vars:
+        ansible_become: false
+      tags:
+        - installation
+        - skip_ansible_lint
+      run_once: true
+      delegate_to: 127.0.0.1
+      ignore_errors: "{{ ansible_check_mode }}"
 
-- name: Install Consul
-  copy:
-    src: "{{ install_temp.path }}/consul"
-    dest: "{{ consul_bin_path }}/consul"
-    owner: "{{ consul_user }}"
-    group: "{{ consul_group }}"
-    mode: 0755
-  notify:
-    - restart consul
-  tags: installation
-  ignore_errors: "{{ ansible_check_mode }}"
+    - name: Install Consul
+      copy:
+        src: "{{ install_temp.path }}/consul"
+        dest: "{{ consul_bin_path }}/consul"
+        owner: "{{ consul_user }}"
+        group: "{{ consul_group }}"
+        mode: 0755
+      notify:
+        - restart consul
+      tags: installation
+      ignore_errors: "{{ ansible_check_mode }}"
 
-- name: Daemon reload systemd in case the binaries upgraded
-  systemd:
-    daemon_reload: yes
-  become: true
-  when:
-    - ansible_service_mgr == "systemd"
-    - consul_install_upgrade | bool
-
-- name: Cleanup
-  file:
-    path: "{{ install_temp.path }}"
-    state: "absent"
-  become: false
-  vars:
-    ansible_become: false
-  tags: installation
-  run_once: true
-  delegate_to: 127.0.0.1
-  ignore_errors: "{{ ansible_check_mode }}"
+    - name: Daemon reload systemd in case the binaries upgraded
+      systemd:
+        daemon_reload: yes
+      become: true
+      when:
+        - ansible_service_mgr == "systemd"
+        - consul_install_upgrade | bool
+  always:
+    - name: Cleanup
+      file:
+        path: "{{ install_temp.path }}"
+        state: "absent"
+      become: false
+      vars:
+        ansible_become: false
+      tags: installation
+      run_once: true
+      delegate_to: 127.0.0.1
+      ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -49,9 +49,12 @@
       command: "yum-config-manager --add-repo {{ consul_repo_url }}"
       args:
         creates: /etc/yum.repos.d/hashicorp.repo
-      when: "ansible_distribution|lower == 'redhat' or ansible_distribution|lower == 'centos' or \
-            ansible_distribution|lower == 'fedora' or ansible_distribution|lower == 'amazon' or \
-            ansible_distribution|lower == 'rocky'"
+      when: >
+        ansible_distribution|lower == 'redhat' or
+        ansible_distribution|lower == 'centos' or
+        ansible_distribution|lower == 'fedora' or
+        ansible_distribution|lower == 'amazon' or
+        ansible_distribution|lower == 'rocky'
 
     - name: Add an Apt signing key, uses whichever key is at the URL
       apt_key:

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -36,12 +36,6 @@
     - installation
     - skip_ansible_lint
 
-- name: Check Consul package file
-  stat:
-    path: "/tmp/consul/{{ consul_pkg }}"
-  register: consul_package
-  tags: installation
-
 - name: Download Consul
   get_url:
     url: "{{ consul_zip_url }}"

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -58,16 +58,9 @@
       register: consul_install
       notify:
         - restart consul
+        - reload systemd daemon
       when: consul_download is changed
       tags: installation
-
-    - name: Daemon reload systemd in case the binaries upgraded
-      systemd: daemon_reload=yes
-      become: true
-      when:
-        - ansible_service_mgr == "systemd"
-        - consul_install_upgrade | bool
-        - consul_install is changed
   always:
     - name: Cleanup
       file:

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -8,14 +8,14 @@
   tags: installation
 
 - name: Validate remote Consul directory
-  file:
-    path: /tmp/consul
+  tempfile:
     state: directory
-    mode: 0700
+    prefix: ansible-consul.
+  register: consul_temp_dir
 
 - name: Read Consul package checksum file
   stat:
-    path: "/tmp/consul/consul_{{ consul_version }}_SHA256SUMS"
+    path: "{{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
   register: consul_checksum
   changed_when: false
   tags: installation
@@ -23,13 +23,13 @@
 - name: Download Consul package checksum file
   get_url:
     url: "{{ consul_checksum_file_url }}"
-    dest: "/tmp/consul/consul_{{ consul_version }}_SHA256SUMS"
+    dest: "{{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
     validate_certs: false
   tags: installation
   when: not consul_checksum.stat.exists | bool
 
 - name: Read Consul package checksum
-  shell: "grep {{ consul_pkg }} /tmp/consul/consul_{{ consul_version }}_SHA256SUMS"
+  shell: "grep {{ consul_pkg }} {{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
   register: consul_sha256
   changed_when: false
   tags:
@@ -39,7 +39,7 @@
 - name: Download Consul
   get_url:
     url: "{{ consul_zip_url }}"
-    dest: "/tmp/consul/{{ consul_pkg }}"
+    dest: "{{ consul_temp_dir.path }}/{{ consul_pkg }}"
     checksum: "sha256:{{ consul_sha256.stdout.split(' ')|first }}"
     timeout: 42
   register: consul_download
@@ -48,7 +48,7 @@
 - name: Unarchive Consul and install binary
   unarchive:
     remote_src: true
-    src: "/tmp/consul/{{ consul_pkg }}"
+    src: "{{ consul_temp_dir.path }}/{{ consul_pkg }}"
     dest: "{{ consul_bin_path }}"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
@@ -69,6 +69,6 @@
 
 - name: Cleanup
   file:
-    path: "/tmp/consul"
+    path: "{{ consul_temp_dir.path }}"
     state: absent
   tags: installation

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -13,62 +13,64 @@
     prefix: ansible-consul.
   register: consul_temp_dir
 
-- name: Read Consul package checksum file
-  stat:
-    path: "{{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
-  register: consul_checksum
-  changed_when: false
-  tags: installation
+- name: Download and unarchive Consul
+  block:
+    - name: Read Consul package checksum file
+      stat:
+        path: "{{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
+      register: consul_checksum
+      changed_when: false
+      tags: installation
 
-- name: Download Consul package checksum file
-  get_url:
-    url: "{{ consul_checksum_file_url }}"
-    dest: "{{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
-    validate_certs: false
-  tags: installation
-  when: not consul_checksum.stat.exists | bool
+    - name: Download Consul package checksum file
+      get_url:
+        url: "{{ consul_checksum_file_url }}"
+        dest: "{{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
+        validate_certs: false
+      tags: installation
+      when: not consul_checksum.stat.exists | bool
 
-- name: Read Consul package checksum
-  shell: "grep {{ consul_pkg }} {{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
-  register: consul_sha256
-  changed_when: false
-  tags:
-    - installation
-    - skip_ansible_lint
+    - name: Read Consul package checksum
+      shell: "grep {{ consul_pkg }} {{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
+      register: consul_sha256
+      changed_when: false
+      tags:
+        - installation
+        - skip_ansible_lint
 
-- name: Download Consul
-  get_url:
-    url: "{{ consul_zip_url }}"
-    dest: "{{ consul_temp_dir.path }}/{{ consul_pkg }}"
-    checksum: "sha256:{{ consul_sha256.stdout.split(' ')|first }}"
-    timeout: 42
-  register: consul_download
-  tags: installation
+    - name: Download Consul
+      get_url:
+        url: "{{ consul_zip_url }}"
+        dest: "{{ consul_temp_dir.path }}/{{ consul_pkg }}"
+        checksum: "sha256:{{ consul_sha256.stdout.split(' ')|first }}"
+        timeout: 42
+      register: consul_download
+      tags: installation
 
-- name: Unarchive Consul and install binary
-  unarchive:
-    remote_src: true
-    src: "{{ consul_temp_dir.path }}/{{ consul_pkg }}"
-    dest: "{{ consul_bin_path }}"
-    owner: "{{ consul_user }}"
-    group: "{{ consul_group }}"
-    mode: 0755
-  register: consul_install
-  notify:
-    - restart consul
-  when: consul_download is changed
-  tags: installation
+    - name: Unarchive Consul and install binary
+      unarchive:
+        remote_src: true
+        src: "{{ consul_temp_dir.path }}/{{ consul_pkg }}"
+        dest: "{{ consul_bin_path }}"
+        owner: "{{ consul_user }}"
+        group: "{{ consul_group }}"
+        mode: 0755
+      register: consul_install
+      notify:
+        - restart consul
+      when: consul_download is changed
+      tags: installation
 
-- name: Daemon reload systemd in case the binaries upgraded
-  systemd: daemon_reload=yes
-  become: true
-  when:
-    - ansible_service_mgr == "systemd"
-    - consul_install_upgrade | bool
-    - consul_install is changed
-
-- name: Cleanup
-  file:
-    path: "{{ consul_temp_dir.path }}"
-    state: absent
-  tags: installation
+    - name: Daemon reload systemd in case the binaries upgraded
+      systemd: daemon_reload=yes
+      become: true
+      when:
+        - ansible_service_mgr == "systemd"
+        - consul_install_upgrade | bool
+        - consul_install is changed
+  always:
+    - name: Cleanup
+      file:
+        path: "{{ consul_temp_dir.path }}"
+        state: absent
+      tags: installation

--- a/tasks/install_windows.yml
+++ b/tasks/install_windows.yml
@@ -1,12 +1,6 @@
 ---
 # File: install_remote.yml - package installation tasks for Consul
 
-- name: Create temporary directory to download Consul
-  win_tempfile:
-    state: directory
-    prefix: ansible-consul.
-  register: consul_temp_dir
-
 - name: Verify TLS1.2 is used
   win_regedit:
     path: HKLM:\SOFTWARE\Microsoft\.NETFramework\v4.0.30319
@@ -14,53 +8,61 @@
     data: 1
     type: dword
 
-- name: Read Consul package checksum file
-  win_stat:
-    path: "{{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
-  register: consul_checksum
-  tags: installation
+- name: Create temporary directory to download Consul
+  win_tempfile:
+    state: directory
+    prefix: ansible-consul.
+  register: consul_temp_dir
 
-- name: Download Consul package checksum file
-  win_get_url:
-    url: "{{ consul_checksum_file_url }}"
-    dest: "{{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
-  tags: installation
-  when: not consul_checksum.stat.exists | bool
+- name: Download and unarchive Consul
+  block:
+    - name: Read Consul package checksum file
+      win_stat:
+        path: "{{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
+      register: consul_checksum
+      tags: installation
 
-- name: Read Consul package checksum
-  win_shell: "findstr {{ consul_pkg }} {{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
-  args:
-    chdir: "{{ consul_temp_dir.path }}"
-  register: consul_pkg_checksum
-  tags: installation
+    - name: Download Consul package checksum file
+      win_get_url:
+        url: "{{ consul_checksum_file_url }}"
+        dest: "{{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
+      tags: installation
+      when: not consul_checksum.stat.exists | bool
 
-- name: Download Consul
-  win_get_url:
-    url: "{{ consul_zip_url }}"
-    dest: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
-  tags: installation
+    - name: Read Consul package checksum
+      win_shell: "findstr {{ consul_pkg }} {{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
+      args:
+        chdir: "{{ consul_temp_dir.path }}"
+      register: consul_pkg_checksum
+      tags: installation
 
-- name: Calculate checksum
-  win_stat:
-    path: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
-    checksum_algorithm: sha256
-  register: consul_pkg_hash
-  tags: installation
+    - name: Download Consul
+      win_get_url:
+        url: "{{ consul_zip_url }}"
+        dest: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
+      tags: installation
 
-- name: Compare checksum to hashfile
-  fail:
-    msg: "Checksum {{ consul_pkg_checksum.stdout.split(' ') | first }} did not match calculated SHA256 {{ consul_pkg_hash.stat.checksum }}!"
-  when:
-    - consul_pkg_hash.stat.checksum != (consul_pkg_checksum.stdout.split(' ') | first)
+    - name: Calculate checksum
+      win_stat:
+        path: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
+        checksum_algorithm: sha256
+      register: consul_pkg_hash
+      tags: installation
 
-- name: Unarchive Consul and install binary
-  win_unzip:
-    src: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
-    dest: "{{ consul_bin_path }}"
-  tags: installation
+    - name: Compare checksum to hashfile
+      fail:
+        msg: "Checksum {{ consul_pkg_checksum.stdout.split(' ') | first }} did not match calculated SHA256 {{ consul_pkg_hash.stat.checksum }}!"
+      when:
+        - consul_pkg_hash.stat.checksum != (consul_pkg_checksum.stdout.split(' ') | first)
 
-- name: Cleanup
-  win_file:
-    path: "{{ consul_temp_dir.path }}"
-    state: absent
-  tags: installation
+    - name: Unarchive Consul and install binary
+      win_unzip:
+        src: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
+        dest: "{{ consul_bin_path }}"
+      tags: installation
+  always:
+    - name: Cleanup
+      win_file:
+        path: "{{ consul_temp_dir.path }}"
+        state: absent
+      tags: installation

--- a/tasks/install_windows.yml
+++ b/tasks/install_windows.yml
@@ -1,10 +1,11 @@
 ---
 # File: install_remote.yml - package installation tasks for Consul
 
-- name: Validate remote Consul directory
-  win_file:
-    path: /tmp/consul
+- name: Create temporary directory to download Consul
+  win_tempfile:
     state: directory
+    prefix: ansible-consul.
+  register: consul_temp_dir
 
 - name: Verify TLS1.2 is used
   win_regedit:
@@ -15,33 +16,33 @@
 
 - name: Read Consul package checksum file
   win_stat:
-    path: "/tmp/consul/consul_{{ consul_version }}_SHA256SUMS"
+    path: "{{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
   register: consul_checksum
   tags: installation
 
 - name: Download Consul package checksum file
   win_get_url:
     url: "{{ consul_checksum_file_url }}"
-    dest: "/tmp/consul/consul_{{ consul_version }}_SHA256SUMS"
+    dest: "{{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
   tags: installation
   when: not consul_checksum.stat.exists | bool
 
 - name: Read Consul package checksum
-  win_shell: "findstr {{ consul_pkg }} /tmp/consul/consul_{{ consul_version }}_SHA256SUMS"
+  win_shell: "findstr {{ consul_pkg }} {{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
   args:
-    chdir: /tmp/consul
+    chdir: "{{ consul_temp_dir.path }}"
   register: consul_pkg_checksum
   tags: installation
 
 - name: Download Consul
   win_get_url:
     url: "{{ consul_zip_url }}"
-    dest: "/tmp/consul/{{ consul_pkg }}"
+    dest: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
   tags: installation
 
 - name: Calculate checksum
   win_stat:
-    path: "/tmp/consul/{{ consul_pkg }}"
+    path: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
     checksum_algorithm: sha256
   register: consul_pkg_hash
   tags: installation
@@ -54,12 +55,12 @@
 
 - name: Unarchive Consul and install binary
   win_unzip:
-    src: "/tmp/consul/{{ consul_pkg }}"
+    src: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
     dest: "{{ consul_bin_path }}"
   tags: installation
 
 - name: Cleanup
   win_file:
-    path: "/tmp/consul"
+    path: "{{ consul_temp_dir.path }}"
     state: absent
   tags: installation

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -43,10 +43,21 @@
   stat:
     path: "{{ consul_binary }}"
   register: consul_binary_installed
+  when: not consul_force_install
+
+- name: Get current Consul version
+  command: "{{ consul_binary }} --version"
+  changed_when: false
+  when:
+    - not consul_force_install
+    - consul_binary_installed.stat.exists
+  register: consul_installed_version
 
 - name: Calculate whether to install consul binary
   set_fact:
-    consul_install_binary: "{{ consul_install_upgrade | bool or not consul_binary_installed.stat.exists }}"
+    consul_install_binary: "{{ consul_force_install or \
+      not consul_binary_installed.stat.exists or \
+      consul_installed_version.stdout_lines[0] != _consul_expected_version_string }}"
 
 - name: Install OS packages and consul - locally
   include_tasks: install.yml

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -33,9 +33,19 @@
     path: "{{ consul_binary }}"
   register: consul_binary_installed
 
+- name: (Windows) Get current Consul version
+  win_command: "{{ consul_binary }} --version"
+  changed_when: false
+  when:
+    - not consul_force_install
+    - consul_binary_installed.stat.exists
+  register: consul_installed_version
+
 - name: (Windows) Calculate whether to install consul binary
   set_fact:
-    consul_install_binary: "{{ not consul_binary_installed.stat.exists }}"
+    consul_install_binary: "{{ consul_force_install or \
+      not consul_binary_installed.stat.exists or \
+      consul_installed_version.stdout_lines[0] != _consul_expected_version_string }}"
 
 - name: (Windows) Install OS packages and consul
   include_tasks: install_windows.yml

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -33,10 +33,13 @@
     path: "{{ consul_binary }}"
   register: consul_binary_installed
 
+- name: (Windows) Calculate whether to install consul binary
+  set_fact:
+    consul_install_binary: "{{ not consul_binary_installed.stat.exists }}"
+
 - name: (Windows) Install OS packages and consul
   include_tasks: install_windows.yml
-  when:
-    - not consul_binary_installed.stat.exists | bool
+  when: consul_install_binary | bool
 
 - block:
     - block:

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -67,7 +67,7 @@
       copy:
         content: "{{ consul_raw_key }}"
         dest: '/tmp/consul_raw.key'
-        mode: 0700
+        mode: 0600
       become: false
       vars:
         ansible_become: false
@@ -88,7 +88,7 @@
           copy:
             content: "{{ consul_keygen.stdout }}"
             dest: '/tmp/consul_raw.key'
-            mode: 0700
+            mode: 0600
           become: false
           vars:
             ansible_become: false

--- a/tests/test_vars.yml
+++ b/tests/test_vars.yml
@@ -46,7 +46,6 @@ consul_checksum_file_url: "https://releases.hashicorp.com/consul/{{ consul_versi
 
 ### Install Method
 consul_install_remotely: false
-consul_install_upgrade: false
 
 ### Paths
 consul_bin_path: "/usr/local/bin"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -33,3 +33,5 @@ _consul_bootstrap_servers: "\
   {% endfor %}\
   {{ __consul_bootstrap_servers }}"
 _consul_bootstrap_server: "{{ _consul_bootstrap_servers[0] }}"
+
+_consul_expected_version_string: "Consul v{{ consul_version }}"


### PR DESCRIPTION
This PR introduces a new variable, `consul_force_install`, which when true, will forcibly install Consul on the host. Otherwise, when this role runs, the Consul version is inspected with `consul --version` and compared to `consul_version` to determine if an upgrade is necessary. Thus, the `consul_install_upgrade` variable is no longer necessary and has been removed by this PR.

This PR also contains a few small cleanups and fixes, primarily for Windows (which I suspect is somewhat less rigorously tested than other platforms).

I have tested these changes locally to make sure that initial installation, idempotent installation, and an upgrade all work correctly. I have tested on the following platforms:

- Linux (Ubuntu 20.04)
- Mac 10.15
- Windows 10

Fixes https://github.com/ansible-community/ansible-consul/issues/87