### PR TITLE
dnsmasq: update the "Disable systemd-resolved" tasks

### DIFF
--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -49,6 +49,11 @@
   when: ansible_service_mgr == "systemd"
   block:
 
+    - name: Check if systemd-resolved service exists
+      stat:
+        path: /lib/systemd/system/systemd-resolved.service
+      register: systemd_resolved_service
+
     - name: Disable systemd-resolved service
       service:
         name: systemd-resolved
@@ -57,6 +62,7 @@
         # Needed to force SysV service manager on Docker for Molecule tests
         use: "{{ ansible_service_mgr }}"
       become: true
+      when: systemd_resolved_service.stat.exists
 
     - name: Check if resolv.conf is pointing to systemd-resolved
       stat:

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -63,12 +63,24 @@
         path: /etc/resolv.conf
       register: resolv_dot_conf
 
-    - name: Remove resolv.conf association with systemd-resolved
-      file:
-        src: /run/resolvconf/resolv.conf
-        path: /etc/resolv.conf
-        state: link
+    - name: Configure resolv.conf for dnsmasq
+      block:
+        - name: Remove resolv.conf association with systemd-resolved
+          file:
+            path: /etc/resolv.conf
+            state: absent
+
+        - name: Add a nameserver entry poining to localhost for dnsmasq
+          lineinfile:
+            path: /etc/resolv.conf
+            regexp: "^nameserver 127.0.0.1"
+            line: "nameserver 127.0.0.1"
+            create: true
+            owner: root
+            group: root
+            mode: "u=rw,g=r,o=r"
       become: true
       when:
+        - resolv_dot_conf.stat.exists
         - resolv_dot_conf.stat.islnk
-        - 'resolv_dot_conf.stat.lnk_source == "/run/systemd/resolve/stub-resolv.conf"'
+        - resolv_dot_conf.stat.lnk_source == "/run/systemd/resolve/stub-resolv.conf"


### PR DESCRIPTION
Fixed:

ERROR: `src file does not exist`

```
TASK [consul : Disable systemd-resolved service] ****************************************************************************************************************************************************************
changed: [172.31.15.62]
changed: [3.223.140.234]
changed: [172.31.5.27]

TASK [consul : Check if resolv.conf is pointing to systemd-resolved] ********************************************************************************************************************************************
ok: [172.31.15.62]
ok: [3.223.140.234]
ok: [172.31.5.27]

TASK [consul : Remove resolv.conf association with systemd-resolved] ********************************************************************************************************************************************
fatal: [3.223.140.234]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "0777", "msg": "src file does not exist, use \"force=yes\" if you really want to create the link: /run/resolvconf/resolv.conf", "owner": "root", "path": "/etc/resolv.conf", "size": 39, "src": "/run/resolvconf/resolv.conf", "state": "link", "uid": 0}
fatal: [172.31.15.62]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "0777", "msg": "src file does not exist, use \"force=yes\" if you really want to create the link: /run/resolvconf/resolv.conf", "owner": "root", "path": "/etc/resolv.conf", "size": 39, "src": "/run/resolvconf/resolv.conf", "state": "link", "uid": 0}
fatal: [172.31.5.27]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "0777", "msg": "src file does not exist, use \"force=yes\" if you really want to create the link: /run/resolvconf/resolv.conf", "owner": "root", "path": "/etc/resolv.conf", "size": 39, "src": "/run/resolvconf/resolv.conf", "state": "link", "uid": 0}

NO MORE HOSTS LEFT **********************************************************************************************************************************************************************************************

PLAY RECAP ******************************************************************************************************************************************************************************************************
172.31.15.62               : ok=48   changed=19   unreachable=0    failed=1    skipped=68   rescued=0    ignored=0   
172.31.5.27                : ok=54   changed=21   unreachable=0    failed=1    skipped=69   rescued=0    ignored=1   
3.223.140.234              : ok=48   changed=19   unreachable=0    failed=1    skipped=68   rescued=0    ignored=0   
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   

ubuntu@ip-172-31-5-27:~/postgresql_cluster$ ls -la /etc/resolv.conf
lrwxrwxrwx 1 root root 39 Dec  1 11:06 /etc/resolv.conf -> ../run/systemd/resolve/stub-resolv.conf
ubuntu@ip-172-31-5-27:~/postgresql_cluster$ ls -la /run/resolvconf/resolv.conf
ls: cannot access '/run/resolvconf/resolv.conf': No such file or directory
```

Test result:

```
ubuntu@source-pgnode02:~$ cat /etc/dnsmasq.d/10-consul
server=/consul/127.0.0.1#8600
server=8.8.8.8
server=8.8.4.4
ubuntu@source-pgnode02:~$ ls -la /etc/resolv.conf 
-rw-r--r-- 1 root root 21 Jan  4 19:22 /etc/resolv.conf
ubuntu@source-pgnode02:~$ 
ubuntu@source-pgnode02:~$ cat /etc/resolv.conf 
nameserver 127.0.0.1
ubuntu@source-pgnode02:~$ 
ubuntu@source-pgnode02:~$ dig +short master.patroni.service.consul SRV
1 1 6432 source-pgnode01.node.us-east-1d.consul.
```