### PR TITLE
Stop consul service on Windows before installation

### DIFF
--- a/tasks/install_windows.yml
+++ b/tasks/install_windows.yml
@@ -8,6 +8,19 @@
     data: 1
     type: dword
 
+- name: See if Consul service exists
+  ansible.windows.win_service_info:
+    name: "Consul"
+  register: win_consul_service
+
+- name: Stop Consul service on Windows
+  ansible.windows.win_service:
+    name: "Consul"
+    state: stopped
+  when:
+    - win_consul_service.exists
+    - win_consul_service.services[0].state == "started"
+
 - name: Create temporary directory to download Consul
   win_tempfile:
     state: directory

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -167,7 +167,7 @@
       register: consul_configd_path_win
 
     - name: Create Consul as a service
-      win_service:
+      ansible.windows.win_service:
         name: Consul
         path: "{{ consul_binary_win.stat.path }} agent \
           -config-file={{ consul_config_path_win.stat.path }}\\config.json \
@@ -192,6 +192,13 @@
       when: consul_iptables_enable | bool
 
   when: not bootstrap_state.stat.exists
+
+# The service is stopped before updating Consul
+- name: Ensure Consul service is started
+  win_service:
+    name: Consul
+    state: started
+  when: bootstrap_state.stat.exists
 
 - include_tasks: ../tasks/dnsmasq.yml
   when: consul_dnsmasq_enable | bool


### PR DESCRIPTION
The Consul service must be stopped or else updating to newer versions will fail with an error:

> `The process cannot access the file 'consul.exe' because it is being used by another process.`