### PR TITLE
Works on my cgroups

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -18,10 +18,15 @@ jobs:
           - almalinux-9
           - centos-7
           - centos-stream-8
+          - debian-8
+          - debian-9
+          - debian-10
           - fedora-37
           - oraclelinux-7
           - oraclelinux-8
           - rockylinux-8
+          - ubuntu-16.04
+          - ubuntu-18.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -18,14 +18,12 @@ jobs:
           - almalinux-9
           - centos-7
           - centos-stream-8
-          - debian-8
           - debian-9
           - debian-10
           - fedora-37
           - oraclelinux-7
           - oraclelinux-8
           - rockylinux-8
-          - ubuntu-16.04
           - ubuntu-18.04
 
     steps:

--- a/molecule/debian-10/molecule.yml
+++ b/molecule/debian-10/molecule.yml
@@ -8,6 +8,7 @@ platforms:
     dockerfile: ../_shared/Dockerfile.j2
     capabilities:
       - SYS_ADMIN
+    cgroupns_mode: host
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/molecule/debian-8/molecule.yml
+++ b/molecule/debian-8/molecule.yml
@@ -5,7 +5,8 @@ platforms:
       - consul_instances
     image: dokken/debian-8
     command: /lib/systemd/systemd
+    cgroupns_mode: host
     dockerfile: ../_shared/Dockerfile.j2
     privileged: True
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/debian-9/molecule.yml
+++ b/molecule/debian-9/molecule.yml
@@ -8,6 +8,7 @@ platforms:
     dockerfile: ../_shared/Dockerfile.j2
     capabilities:
       - SYS_ADMIN
+    cgroupns_mode: host
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/molecule/ubuntu-16.04/molecule.yml
+++ b/molecule/ubuntu-16.04/molecule.yml
@@ -8,6 +8,7 @@ platforms:
     dockerfile: ../_shared/Dockerfile.j2
     capabilities:
       - SYS_ADMIN
+    cgroupns_mode: host
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/molecule/ubuntu-18.04/molecule.yml
+++ b/molecule/ubuntu-18.04/molecule.yml
@@ -8,6 +8,7 @@ platforms:
     dockerfile: ../_shared/Dockerfile.j2
     capabilities:
       - SYS_ADMIN
+    cgroupns_mode: host
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true


### PR DESCRIPTION
Thanks to a [comment](https://github.com/ansible-community/ansible-consul/pull/520#issuecomment-1378618902) by [@vitabaks](https://github.com/vitabaks) some debian/ubuntu scenarios can be re-enabled in molecule testing.

