### PR TITLE
Add ansible-lint ingnore rule "fqcn-builtins"

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,6 +4,7 @@ skip_list:
   - "key-order[task]"
   - "fqcn[action-core]"
   - "fqcn[action]"
+  - "fqcn-builtins"
   - "ignore-errors"
   - "jinja[spacing]"
   - "no-changed-when"


### PR DESCRIPTION
Ignore the hint to use fqcn-names even for builtin modules.