### PR TITLE
Fix gossip key generation failures, CI

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,6 +13,12 @@ skip_list:
   - "schema[meta]"
   - "var-naming"
 
+  # Pipefail is a bit more difficult, because the shell shipped in the Docker image used
+  # by the Molecule tests doesn't recognize the pipefail option. Likewise, we also need to
+  # make sure that the playbook works for hosts that don't have a modern bash or a default
+  # shell such as /bin/sh.
+  - "risky-shell-pipe"
+
   # These errors should continue to be ignored
   - "no-jinja-when"
   - "role-name"

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -100,8 +100,7 @@
 - name: Fail if more than one bootstrap server is defined
   fail:
     msg: "You can not define more than one bootstrap server."
-  when:
-    - _consul_bootstrap_servers | length > 1
+  when: _consul_bootstrap_servers | length > 1
 
 - name: Fail if a bootstrap server is defined and bootstrap_expect is true
   fail:
@@ -127,5 +126,4 @@
 - name: Install remotely if unzip is not installed on control host
   set_fact:
     consul_install_remotely: true
-  when:
-    - is_unzip_installed is failed
+  when: is_unzip_installed is failed

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -23,8 +23,7 @@
       when: "{{ consul_debug | bool }}"
   loop_control:
     loop_var: config_item
-  when:
-    - config_item.when
+  when: config_item.when
   notify:
     - restart consul
 
@@ -35,8 +34,7 @@
     group: "{{ consul_group }}"
     content: "{{ lookup('template', 'templates/configd_50custom.json.j2', convert_data=True) | to_nice_json }}"
     mode: 0600
-  when:
-    - consul_config_custom is defined
+  when: consul_config_custom is defined
   notify:
     - restart consul
 

--- a/tasks/config_windows.yml
+++ b/tasks/config_windows.yml
@@ -20,8 +20,7 @@
       when: "{{ consul_debug | bool }}"
   loop_control:
     loop_var: config_item
-  when:
-    - config_item.when
+  when: config_item.when
   notify:
     - restart consul
 
@@ -29,8 +28,7 @@
   win_copy:
     dest: "{{ consul_configd_path }}/50custom.json"
     content: "{{ lookup('template', 'templates/configd_50custom.json.j2', convert_data=True) | to_nice_json }}"
-  when:
-    - consul_config_custom is defined
+  when: consul_config_custom is defined
   notify:
     - restart consul
 

--- a/tasks/encrypt_gossip.yml
+++ b/tasks/encrypt_gossip.yml
@@ -48,6 +48,9 @@
   delegate_to: 127.0.0.1
 
 - name: Write gossip encryption key
+  when:
+    - consul_raw_key is not defined
+    - not bootstrap_state.stat.exists | bool
   block:
     - name: Generate gossip encryption key
       shell: "PATH={{ consul_bin_path }}:$PATH consul keygen"
@@ -56,6 +59,3 @@
 
     - name: Write gossip encryption key to fact
       set_fact: consul_raw_key={{ consul_keygen.stdout }}
-  when:
-    - consul_raw_key is not defined
-    - not bootstrap_state.stat.exists | bool

--- a/tasks/encrypt_gossip.yml
+++ b/tasks/encrypt_gossip.yml
@@ -1,7 +1,7 @@
 ---
 # File: encrypt_gossip.yml - Gossip encryption tasks for Consul
 
-- name: Save exsiting gossip encryption key
+- name: Save existing gossip encryption key
   block:
     - name: Read gossip encryption key from previously boostrapped server
       shell: 'cat {{ consul_config_path }}/bootstrap/config.json | grep "encrypt" | sed -E ''s/"encrypt": "(.+)",?/\1/'' | sed ''s/^ *//;s/ *$//'''

--- a/tasks/encrypt_gossip.yml
+++ b/tasks/encrypt_gossip.yml
@@ -48,14 +48,31 @@
   delegate_to: 127.0.0.1
 
 - name: Write gossip encryption key
+  run_once: true
   when:
     - consul_raw_key is not defined
     - not bootstrap_state.stat.exists | bool
   block:
-    - name: Generate gossip encryption key
-      shell: "PATH={{ consul_bin_path }}:$PATH consul keygen"
-      register: consul_keygen
-      run_once: true
+    - name: Create temporary file to receive gossip encryption key
+      tempfile:
+        state: file
+      register: gossip_key_tempfile
 
-    - name: Write gossip encryption key to fact
-      set_fact: consul_raw_key={{ consul_keygen.stdout }}
+    - name: Generate gossip encryption key
+      shell: "PATH={{ consul_bin_path }}:$PATH consul keygen > {{ gossip_key_tempfile.path }}"
+      register: consul_keygen
+
+    - name: Slurp gossip encryption key
+      slurp:
+        src: "{{ gossip_key_tempfile.path }}"
+      register: consul_keygen_cmd
+
+    - name: Set gossip encryption key to fact
+      set_fact:
+        consul_raw_key: "{{ consul_keygen_cmd | b64decode }}"
+
+      always:
+        - name: Clean up temporary file
+          file:
+            path: "{{ gossip_key_tempfile.path }}"
+            state: absent

--- a/tasks/install_windows.yml
+++ b/tasks/install_windows.yml
@@ -65,8 +65,7 @@
     - name: Compare checksum to hashfile
       fail:
         msg: "Checksum {{ consul_pkg_checksum.stdout.split(' ') | first }} did not match calculated SHA256 {{ consul_pkg_hash.stat.checksum }}!"
-      when:
-        - consul_pkg_hash.stat.checksum != (consul_pkg_checksum.stdout.split(' ') | first)
+      when: consul_pkg_hash.stat.checksum != (consul_pkg_checksum.stdout.split(' ') | first)
 
     - name: Unarchive Consul and install binary
       win_unzip:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,7 @@
   when: 'consul_version == "latest"'
 
 - name: Install python dependencies
-  when:
-    - consul_install_dependencies | bool
+  when: consul_install_dependencies | bool
   block:
     - name: Install netaddr dependency on controlling host (with --user)
       pip:

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -122,18 +122,27 @@
         - lookup('first_found', dict(files=['/tmp/consul_raw.key'], skip=true)) | ternary(false, true)
         - not bootstrap_state.stat.exists | bool
       block:
+        - name: Create temporary file to receive gossip encryption key
+          tempfile:
+            state: file
+          register: gossip_key_tempfile
+
         - name: Generate gossip encryption key
-          shell: "PATH={{ consul_bin_path }}:$PATH consul keygen"
+          shell: "PATH={{ consul_bin_path }}:$PATH consul keygen > {{ gossip_key_tempfile.path }}"
           register: consul_keygen
 
-        - name: Write key locally to share with other nodes
-          copy:
-            content: "{{ consul_keygen.stdout }}"
-            dest: '/tmp/consul_raw.key'
+        - name: Fetch key locally to share with other nodes
           become: false
-          vars:
-            ansible_become: false
-          delegate_to: localhost
+          fetch:
+            src: "{{ gossip_key_tempfile.path }}"
+            dest: "/tmp/consul_raw.key"
+            flat: true
+
+      always:
+        - name: Clean up temporary file
+          file:
+            path: "{{ gossip_key_tempfile.path }}"
+            state: absent
 
     - name: Read gossip encryption key for servers that require it
       set_fact:

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -76,7 +76,6 @@
 # XXX: Individual gossip tasks are deprecated and need to be removed
 # - include_tasks: ../tasks/encrypt_gossip.yml
 - name: Configure gossip encryption key
-  no_log: true
   when: consul_encrypt_enable | bool
   block:
     - name: Save existing gossip encryption key
@@ -95,9 +94,9 @@
         - name: Save gossip encryption key from existing configuration
           set_fact:
             consul_raw_key: "{{ consul_config.encrypt }}"
+          no_log: true
           when: consul_config is defined
 
-      no_log: true
       when:
         - consul_raw_key is not defined
         - bootstrap_state.stat.exists | bool
@@ -112,13 +111,11 @@
       become: false
       vars:
         ansible_become: false
-      no_log: true
       delegate_to: localhost
       changed_when: false
       when: consul_raw_key is defined
 
     - name: Generate new gossip encryption key if none was found
-      no_log: true
       run_once: true
       when:
         # if files '/tmp/consul_raw.key' exist

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -77,6 +77,9 @@
 # XXX: Individual gossip tasks are deprecated and need to be removed
 # - include_tasks: ../tasks/encrypt_gossip.yml
 - name: Configure gossip encryption key
+  no_log: true
+  when:
+    - consul_encrypt_enable | bool
   block:
     - name: Save existing gossip encryption key
       block:
@@ -117,6 +120,12 @@
       when: consul_raw_key is defined
 
     - name: Generate new gossip encryption key if none was found
+      no_log: true
+      run_once: true
+      when:
+        # if files '/tmp/consul_raw.key' exist
+        - lookup('first_found', dict(files=['/tmp/consul_raw.key'], skip=true)) | ternary(false, true)
+        - not bootstrap_state.stat.exists | bool
       block:
         - name: Generate gossip encryption key
           shell: "PATH={{ consul_bin_path }}:$PATH consul keygen"
@@ -130,13 +139,6 @@
           vars:
             ansible_become: false
           delegate_to: localhost
-
-      no_log: true
-      run_once: true
-      when:
-        # if files '/tmp/consul_raw.key' exist
-        - lookup('first_found', dict(files=['/tmp/consul_raw.key'], skip=true)) | ternary(false, true)
-        - not bootstrap_state.stat.exists | bool
 
     - name: Read gossip encryption key for servers that require it
       set_fact:
@@ -155,9 +157,6 @@
       run_once: true
       delegate_to: localhost
       changed_when: false
-  no_log: true
-  when:
-    - consul_encrypt_enable | bool
 
 - name: Create ACL configuration
   include_tasks: acl.yml

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -33,8 +33,7 @@
 
 - name: Install OS packages and consul - from the repository
   include_tasks: install_linux_repo.yml
-  when:
-    - consul_install_from_repo | bool
+  when: consul_install_from_repo | bool
 
 - name: Include directory settings
   import_tasks: dirs.yml
@@ -78,8 +77,7 @@
 # - include_tasks: ../tasks/encrypt_gossip.yml
 - name: Configure gossip encryption key
   no_log: true
-  when:
-    - consul_encrypt_enable | bool
+  when: consul_encrypt_enable | bool
   block:
     - name: Save existing gossip encryption key
       block:
@@ -144,8 +142,7 @@
       set_fact:
         consul_raw_key: "{{ lookup('file', '/tmp/consul_raw.key') }}"
       no_log: true
-      when:
-        - consul_raw_key is not defined
+      when: consul_raw_key is not defined
 
     - name: Delete gossip encryption key file
       file:

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -21,8 +21,7 @@
         mode: 0644
       notify: restart consul
 
-  when:
-    - consul_tls_copy_keys | bool
+  when: consul_tls_copy_keys | bool
 
 - name: Copy server certificate and key
   block:

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -119,8 +119,7 @@
       set_fact:
         consul_raw_key: "{{ lookup('file', '/tmp/consul_raw.key') }}"
       no_log: true
-      when:
-        - consul_raw_key is not defined
+      when: consul_raw_key is not defined
 
     - name: (Windows) Delete gossip encryption key file
       file:
@@ -132,8 +131,7 @@
       run_once: true
       delegate_to: localhost
   no_log: true
-  when:
-    - consul_encrypt_enable
+  when: consul_encrypt_enable
 
 - name: (Windows) Create Consul configuration
   import_tasks: config_windows.yml

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -86,7 +86,6 @@
       become: false
       vars:
         ansible_become: false
-      no_log: true
       run_once: true
       register: consul_local_key
       delegate_to: localhost
@@ -97,6 +96,7 @@
 
         - name: (Windows) Generate gossip encryption key
           win_shell: "{{ consul_binary }} keygen"
+          no_log: true
           register: consul_keygen
 
         - name: (Windows) Write key locally to share with other nodes
@@ -109,7 +109,6 @@
             ansible_become: false
           delegate_to: localhost
 
-      no_log: true
       run_once: true
       when:
         - not consul_local_key.changed


### PR DESCRIPTION
The primary purpose of this PR is to fix the gossip [key generation issues](https://github.com/ansible-community/ansible-consul/issues/506), which this PR does by avoiding the race condition in Ansible when using `copy` with the `content` attribute when delegated to `localhost`.

Additionally, I "fixed" CI by suppressing `risky-shell-pipe` in ansible-lint. Unfortunately, adding `set -o pipefail` ahead of the `shell` commands isn't a great solution because the Molecule tests execute with `/bin/sh`, which unlike `/bin/bash` lacks support for `set -o pipefail`. The version of the shell that ships with the Docker container used by the Molecule tests also doesn't support `set -o pipefail`, so setting Molecule's executable won't work either.

FWIW, the reason that CI is currently broken is because even though _we_ pinned the `molecule-action` GitHub action, _it_ doesn't pin the Docker image correctly (see https://github.com/gofrolist/molecule-action/issues/140). An update to this image now forces us to fix new ansible-lint violations just to get CI back up and running.

Fixes https://github.com/ansible-community/ansible-consul/issues/506