### PR TITLE
Run ansible-lint in its own workflow

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,7 @@
 ---
 skip_list:
   # TODO: Fix ansible-lint violations for these errors and remove from skip_list
+  - "fqcn-builtins"
   - "fqcn[action-core]"
   - "fqcn[action]"
   - "ignore-errors"
@@ -12,6 +13,7 @@ skip_list:
   - "risky-file-permissions"
   - "schema[meta]"
   - "var-naming"
+  - "var-spacing"
 
   # Pipefail is a bit more difficult, because the shell shipped in the Docker image used
   # by the Molecule tests doesn't recognize the pipefail option. Likewise, we also need to

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,11 +1,11 @@
 ---
 skip_list:
   # TODO: Fix ansible-lint violations for these errors and remove from skip_list
-  - "key-order[task]"
   - "fqcn[action-core]"
   - "fqcn[action]"
   - "ignore-errors"
   - "jinja[spacing]"
+  - "key-order[task]"
   - "no-changed-when"
   - "no-free-form"
   - "no-handler"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,46 @@
+---
+name: Ansible-lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: "${{ github.repository }}"
+
+      # This is unfortunately necessary because this role doesn't follow Ansible's rules
+      # for role naming. If we should manage to rename the role, this task could be
+      # eliminated.
+      - name: Configure role symlink
+        run: |
+          sudo mkdir -p /usr/share/ansible/roles
+          sudo ln -s $PWD/${{ github.repository }} /usr/share/ansible/roles/ansible-consul
+
+      # Similar to the above, we can't use Ansible's ansible-lint-action workflow because
+      # it makes too many assumptions for us. We need to install it ourselves and run it
+      # manually. If we could use that action, the next two steps could be removed.
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y python3-pip
+          sudo pip3 install -r ${{ github.repository }}/requirements.txt
+
+      - name: Run ansible-lint
+        run: |
+          ansible-lint --offline -c ${{ github.repository }}/.ansible-lint ${{ github.repository }}
+
+      - name: Run yamllint
+        run: |
+          yamllint -c ${{ github.repository }}/.yamllint ${{ github.repository }}
+
+      - name: Run flake8
+        run: |
+          flake8 ${{ github.repository }}

--- a/molecule/_shared/base.yml
+++ b/molecule/_shared/base.yml
@@ -2,7 +2,6 @@
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare
@@ -16,11 +15,6 @@ dependency:
     requirements-file: requirements.yml
 driver:
   name: docker
-lint: |
-  set -e
-  yamllint .
-  ansible-lint
-  flake8
 role_name_check: 1
 provisioner:
   name: ansible


### PR DESCRIPTION
This is in preparation for Molecule 5.x, which removes the `lint` command. For more information, see:

https://github.com/ansible-community/molecule/pull/3802

Aside from that, this approach is also a bit nicer since linter errors can be identified by their own GitHub checks run, which should be easier for developers compared to the previous approach of having to hunt through Molecule's error logs for linter errors. Also, it's a bit more efficient since we only run the linters once per CI run instead of in every Molecule scenario.
