### PR TITLE
Ensure tempfiles are defined before deleting them

### DIFF
--- a/tasks/encrypt_gossip.yml
+++ b/tasks/encrypt_gossip.yml
@@ -76,3 +76,4 @@
           file:
             path: "{{ gossip_key_tempfile.path }}"
             state: absent
+          when: gossip_key_tempfile is defined

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -143,6 +143,7 @@
           file:
             path: "{{ gossip_key_tempfile.path }}"
             state: absent
+          when: gossip_key_tempfile is defined
 
     - name: Read gossip encryption key for servers that require it
       set_fact:


### PR DESCRIPTION
In some cases, if the block exits early then this variable will be undefined, which would cause a failure.