### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,8 @@ Notice that the dict object has to use precisely the names stated in the documen
 
 - [Minimum acceptable TLS version](https://www.consul.io/docs/agent/options.html#tls_min_version)
   - Can be overridden with `CONSUL_TLS_MIN_VERSION` environment variable
-- Default value: tls12
+  - For versions < 1.12.0 use 'tls12,tls13,...'
+- Default value: TLSv1_2
 
 ### `consul_tls_cipher_suites`
 


### PR DESCRIPTION
Default is set to TLSv1_2 but README said tls12.
Also the documentation and changelogs are not quite clear about when this values are used so i added another point for this after comparing different tags of consul. Seems to have change with 1.11.11 to 1.12.0