### PR TITLE
Create and delete the tempfile as non-root user

### DIFF
--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -132,6 +132,7 @@
         - not bootstrap_state.stat.exists | bool
       block:
         - name: Create temporary file to receive gossip encryption key
+          become: false
           tempfile:
             state: file
           register: gossip_key_tempfile
@@ -149,6 +150,7 @@
 
       always:
         - name: Clean up temporary file
+          become: false
           file:
             path: "{{ gossip_key_tempfile.path }}"
             state: absent


### PR DESCRIPTION
Since the `fetch` task uses non-root privileges, we need to make sure that this is also the same for handling the tempfile. Otherwise, if this role is invoked with `become: true` then the non-privileged user won't be able to `fetch` into the tempfile, since it would be created by root.

---

Fixes https://github.com/ansible-community/ansible-consul/issues/554