### PR TITLE
Update molecule-action to 2.6.10

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Molecule
-        uses: gofrolist/molecule-action@v2.3.13
+        uses: gofrolist/molecule-action@v2.6.10
         with:
           molecule_options: --base-config molecule/_shared/base.yml
           molecule_args: --scenario-name ${{ matrix.scenario }}


### PR DESCRIPTION
2.3.13 was released on Feb 18, 2023, so we're pretty out-of-date. Fortunately everything still seems to work for CI.