### PR TITLE
Add rolling restart on linux.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
     "python.testing.pytestEnabled": true,
-    "python.testing.unittestEnabled": false
+    "python.testing.unittestEnabled": false,
+    "ansible.python.interpreterPath": "/bin/python"
 }

--- a/README.md
+++ b/README.md
@@ -835,6 +835,14 @@ _Consul Enterprise Only (requires that CONSUL_ENTERPRISE is set to true)_
  - If the default config template does not suit your needs, you can replace it with your own.
  - Default value: `templates/config.json.j2`.
 
+### `consul_rolling_restart`
+ - Restarts consul node one by one to avoid service interruption on existing cluster (Unix platforms only).
+ - Default value: *false*
+
+### `consul_rolling_restart_delay_sec`
+ - Adds a delay between node restart (Linux platforms only).
+ - Default value: 5
+
 #### Custom Configuration Section
 
 As Consul loads the configuration from files and directories in lexical order, typically merging on top of previously parsed configuration files, you may set custom configurations via `consul_config_custom`, which will be expanded into a file named `config_z_custom.json` within your `consul_config_path` which will be loaded after all other configuration by default.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,8 @@ consul_checksum_file_url: https://releases.hashicorp.com/consul/{{ consul_versio
 consul_force_install: false
 consul_install_remotely: false
 consul_install_from_repo: false
+consul_rolling_restart: false
+consul_rolling_restart_delay_sec: 5
 
 ### Paths
 consul_bin_path: /usr/local/bin

--- a/handlers/restart_consul.yml
+++ b/handlers/restart_consul.yml
@@ -13,6 +13,20 @@
     # Needed to force SysV service manager on Docker for Molecule tests
     use: "{{ ansible_service_mgr }}"
   when:
+    - not consul_rolling_restart | bool
+    - ansible_os_family != "Darwin"
+    - ansible_os_family != "Windows"
+  listen: restart consul
+
+- name: Rolling restart consul on Unix
+  # Manual loop on playbook hosts to perform a "serial: 1" equivalent on a set of task
+  ansible.builtin.include_tasks: ../tasks/leave_restart_consul.yml
+  with_items: "{{ play_hosts }}"
+  loop_control:
+    loop_var: rolling_restart_host
+  when:
+    - consul_rolling_restart | bool
+    - inventory_hostname == play_hosts[0]
     - ansible_os_family != "Darwin"
     - ansible_os_family != "Windows"
   listen: restart consul

--- a/tasks/leave_restart_consul.yml
+++ b/tasks/leave_restart_consul.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Consul leave
+  delegate_to: "{{ rolling_restart_host }}"
+  ansible.builtin.command: "{{ consul_binary }} leave {% if consul_acl_enable %} -token {{ consul_acl_master_token }} {% endif %} -http-addr {{ consul_addresses.http }}:{{ consul_ports.http }}"
+  changed_when: true
+
+- name: Restart consul on Unix
+  delegate_to: "{{ rolling_restart_host }}"
+  ansible.builtin.service:
+    name: consul
+    state: restarted
+    # Needed to force SysV service manager on Docker for Molecule tests
+    use: "{{ ansible_service_mgr }}"
+
+- name: Wait for service availability
+  ansible.builtin.pause:
+    seconds: "{{ consul_rolling_restart_delay_sec }}"
+  when: consul_rolling_restart_delay_sec > 0


### PR DESCRIPTION
This patch makes possible to perform rolling restart on linux. When run on an existing cluster, it should keep the cluster up & running. 