### PR TITLE
adding become to service restarts

### DIFF
--- a/handlers/restart_consul.yml
+++ b/handlers/restart_consul.yml
@@ -7,6 +7,7 @@
   listen: reload systemd daemon
 
 - name: Restart consul on Unix
+  become: true
   ansible.builtin.service:
     name: consul
     state: restarted

--- a/handlers/restart_rsyslog.yml
+++ b/handlers/restart_rsyslog.yml
@@ -1,5 +1,6 @@
 ---
 - name: Restart rsyslog
+  become: true
   ansible.builtin.service:
     name: rsyslog
     state: restarted

--- a/handlers/restart_syslogng.yml
+++ b/handlers/restart_syslogng.yml
@@ -1,5 +1,6 @@
 ---
 - name: Restart syslog-ng
+  become: true
   ansible.builtin.service:
     name: syslog-ng
     state: restarted

--- a/handlers/start_consul.yml
+++ b/handlers/start_consul.yml
@@ -1,5 +1,6 @@
 ---
 - name: Start consul on Unix
+  become: true
   ansible.builtin.service:
     name: consul
     state: started

--- a/handlers/start_snapshot.yml
+++ b/handlers/start_snapshot.yml
@@ -1,5 +1,6 @@
 ---
 - name: Start consul snapshot on Unix
+  become: true
   ansible.builtin.service:
     name: consul_snapshot
     state: started


### PR DESCRIPTION
Adding explicit `become` here. My current play seems to be failing if I my actual playbook has `become: false` and only having the `become: true` within `import_role`

The following works:
```
- hosts: target
  become: true
  role: [ansible-consul]
```

I'm failing with this, unless the changes proposed gets applied:
```
- hosts: target
  become: false
  tasks:
    - name: Import role
      become: true
      import_role:
        name: ansible-consul
```