### PR TITLE
Fixed linting against ansible-core version 2.14

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,7 +14,7 @@
     file: reload_consul_conf.yml
 
 - name: Restart dnsmasq
-  service:
+  ansible.builtin.service:
     name: dnsmasq
     enabled: true
     state: restarted
@@ -40,7 +40,7 @@
     file: start_snapshot.yml
 
 - name: Systemctl daemon-reload
-  systemd:
+  ansible.builtin.systemd_service:
     daemon_reload: true
   become: true
   listen: 'systemctl daemon-reload'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,13 +2,16 @@
 # File: main.yml - Handlers for Consul
 
 - name: Restart consul
-  ansible.builtin.import_tasks: restart_consul.yml
+  ansible.builtin.import_tasks:
+    file: restart_consul.yml
 
 - name: Start consul
-  ansible.builtin.import_tasks: start_consul.yml
+  ansible.builtin.import_tasks:
+    file: start_consul.yml
 
 - name: Reload consul configuration
-  ansible.builtin.import_tasks: reload_consul_conf.yml
+  ansible.builtin.import_tasks:
+    file: reload_consul_conf.yml
 
 - name: Restart dnsmasq
   service:
@@ -21,16 +24,20 @@
   listen: 'restart dnsmasq'
 
 - name: Restart rsyslog
-  ansible.builtin.import_tasks: restart_rsyslog.yml
+  ansible.builtin.import_tasks:
+    file: restart_rsyslog.yml
 
 - name: Restart syslog-ng
-  ansible.builtin.import_tasks: restart_syslogng.yml
+  ansible.builtin.import_tasks:
+    file: restart_syslogng.yml
 
 - name: Restart syslog-ng
-  ansible.builtin.import_tasks: restart_syslogng.yml
+  ansible.builtin.import_tasks:
+    file: restart_syslogng.yml
 
 - name: Start snapshot
-  ansible.builtin.import_tasks: start_snapshot.yml
+  ansible.builtin.import_tasks:
+    file: start_snapshot.yml
 
 - name: Systemctl daemon-reload
   systemd:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,13 +2,13 @@
 # File: main.yml - Handlers for Consul
 
 - name: Restart consul
-  import_tasks: restart_consul.yml
+  ansible.builtin.import_tasks: restart_consul.yml
 
 - name: Start consul
-  import_tasks: start_consul.yml
+  ansible.builtin.import_tasks: start_consul.yml
 
 - name: Reload consul configuration
-  import_tasks: reload_consul_conf.yml
+  ansible.builtin.import_tasks: reload_consul_conf.yml
 
 - name: Restart dnsmasq
   service:
@@ -21,16 +21,16 @@
   listen: 'restart dnsmasq'
 
 - name: Restart rsyslog
-  import_tasks: restart_rsyslog.yml
+  ansible.builtin.import_tasks: restart_rsyslog.yml
 
 - name: Restart syslog-ng
-  import_tasks: restart_syslogng.yml
+  ansible.builtin.import_tasks: restart_syslogng.yml
 
 - name: Restart syslog-ng
-  import_tasks: restart_syslogng.yml
+  ansible.builtin.import_tasks: restart_syslogng.yml
 
 - name: Start snapshot
-  import_tasks: start_snapshot.yml
+  ansible.builtin.import_tasks: start_snapshot.yml
 
 - name: Systemctl daemon-reload
   systemd:

--- a/handlers/reload_consul_conf.yml
+++ b/handlers/reload_consul_conf.yml
@@ -3,6 +3,6 @@
 # Cannot use `consul reload` because it requires the HTTP API to be bound to a non-loopback interface
 
 - name: Reload consul configuration on unix
-  command: "pkill --pidfile '{{ consul_run_path }}/consul.pid' --signal SIGHUP"
+  ansible.builtin.command: "pkill --pidfile '{{ consul_run_path }}/consul.pid' --signal SIGHUP"
   when: ansible_os_family != "Windows"
   listen: 'reload consul configuration'

--- a/handlers/restart_consul.yml
+++ b/handlers/restart_consul.yml
@@ -1,13 +1,13 @@
 ---
 - name: Daemon reload systemd in case the binaries upgraded
-  systemd:
+  ansible.builtin.systemd_service:
     daemon_reload: true
   become: true
   when: ansible_service_mgr == "systemd"
   listen: 'reload systemd daemon'
 
 - name: Restart consul on Unix
-  service:
+  ansible.builtin.service:
     name: consul
     state: restarted
     # Needed to force SysV service manager on Docker for Molecule tests
@@ -18,12 +18,12 @@
   listen: 'restart consul'
 
 - name: Restart consul on Mac
-  include_tasks: "{{ role_path }}/handlers/restart_consul_mac.yml"
+  ansible.builtin.include_tasks: "{{ role_path }}/handlers/restart_consul_mac.yml"
   when: ansible_os_family == "Darwin"
   listen: 'restart consul'
 
 - name: Restart consul on Windows
-  win_service:
+  ansible.windows.win_service:
     name: consul
     state: restarted
   # Some tasks with `become: true` end up calling this task. Unfortunately, the `become`

--- a/handlers/restart_consul_mac.yml
+++ b/handlers/restart_consul_mac.yml
@@ -1,6 +1,6 @@
 ---
 - name: (Mac) Stop consul service
-  import_tasks: "stop_consul_mac.yml"
+  ansible.builtin.import_tasks: "stop_consul_mac.yml"
 
 - name: (Mac) Start consul service
-  import_tasks: "start_consul_mac.yml"
+  ansible.builtin.import_tasks: "start_consul_mac.yml"

--- a/handlers/restart_consul_mac.yml
+++ b/handlers/restart_consul_mac.yml
@@ -1,6 +1,8 @@
 ---
 - name: (Mac) Stop consul service
-  ansible.builtin.import_tasks: "stop_consul_mac.yml"
+  ansible.builtin.import_tasks:
+    file: stop_consul_mac.yml
 
 - name: (Mac) Start consul service
-  ansible.builtin.import_tasks: "start_consul_mac.yml"
+  ansible.builtin.import_tasks:
+    file: start_consul_mac.yml

--- a/handlers/restart_rsyslog.yml
+++ b/handlers/restart_rsyslog.yml
@@ -1,6 +1,6 @@
 ---
 - name: Restart rsyslog
-  service:
+  ansible.builtin.service:
     name: rsyslog
     state: restarted
     # Needed to force SysV service manager on Docker for Molecule tests

--- a/handlers/restart_syslogng.yml
+++ b/handlers/restart_syslogng.yml
@@ -1,6 +1,6 @@
 ---
 - name: Restart syslog-ng
-  service:
+  ansible.builtin.service:
     name: syslog-ng
     state: restarted
     # Needed to force SysV service manager on Docker for Molecule tests

--- a/handlers/start_consul.yml
+++ b/handlers/start_consul.yml
@@ -1,6 +1,6 @@
 ---
 - name: Start consul on Unix
-  service:
+  ansible.builtin.service:
     name: consul
     state: started
     # Needed to force SysV service manager on Docker for Molecule tests
@@ -11,12 +11,12 @@
   listen: 'start consul'
 
 - name: Start consul on Mac
-  include_tasks: "{{ role_path }}/handlers/start_consul_mac.yml"
+  ansible.builtin.include_tasks: "{{ role_path }}/handlers/start_consul_mac.yml"
   when: ansible_os_family == "Darwin"
   listen: 'start consul'
 
 - name: Start consul on Windows
-  win_service:
+  ansible.windows.win_service:
     name: consul
     state: started
   when: ansible_os_family == "Windows"

--- a/handlers/start_consul_mac.yml
+++ b/handlers/start_consul_mac.yml
@@ -23,7 +23,8 @@
   # Normally we'd want to use `launchctl list` for this, but it has a nasty habit of
   # randomly not returning the PID in its output, which makes it hard for us to see if the
   # service is running.
-  ansible.builtin.command: "pgrep consul"
+  ansible.builtin.command:
+    cmd: pgrep consul
   changed_when: false
   register: consul_mac_service_pgrep
   retries: 20

--- a/handlers/start_consul_mac.yml
+++ b/handlers/start_consul_mac.yml
@@ -2,13 +2,13 @@
 - name: See if consul service exists
   become: true
   become_user: "{{ consul_user }}"
-  command: "launchctl list {{ consul_launchctl_ident }}"
+  ansible.builtin.command: "launchctl list {{ consul_launchctl_ident }}"
   changed_when: false
   ignore_errors: true
   register: consul_service_list
 
 - name: Get UID for consul user
-  command: "id -u {{ consul_user }}"
+  ansible.builtin.command: "id -u {{ consul_user }}"
   changed_when: false
   register: uid
   when: consul_service_list is failed
@@ -16,14 +16,14 @@
 - name: Load consul service
   become: true
   become_user: "{{ consul_user }}"
-  command: "launchctl bootstrap gui/{{ uid.stdout }} {{ consul_launchctl_plist }}"
+  ansible.builtin.command: "launchctl bootstrap gui/{{ uid.stdout }} {{ consul_launchctl_plist }}"
   when: consul_service_list is failed
 
 - name: Assert that consul service is running
   # Normally we'd want to use `launchctl list` for this, but it has a nasty habit of
   # randomly not returning the PID in its output, which makes it hard for us to see if the
   # service is running.
-  command: "pgrep consul"
+  ansible.builtin.command: "pgrep consul"
   changed_when: false
   register: consul_mac_service_pgrep
   retries: 20

--- a/handlers/start_snapshot.yml
+++ b/handlers/start_snapshot.yml
@@ -1,6 +1,6 @@
 ---
 - name: Start consul snapshot on Unix
-  service:
+  ansible.builtin.service:
     name: consul_snapshot
     state: started
     enabled: true

--- a/handlers/stop_consul_mac.yml
+++ b/handlers/stop_consul_mac.yml
@@ -2,13 +2,13 @@
 - name: See if consul service exists
   become: true
   become_user: "{{ consul_user }}"
-  command: "launchctl list {{ consul_launchctl_ident }}"
+  ansible.builtin.command: "launchctl list {{ consul_launchctl_ident }}"
   changed_when: false
   ignore_errors: true
   register: consul_service_list
 
 - name: Get UID for consul user
-  command: "id -u {{ consul_user }}"
+  ansible.builtin.command: "id -u {{ consul_user }}"
   changed_when: false
   register: uid
   when: consul_service_list is succeeded
@@ -16,7 +16,7 @@
 - name: Unload consul service
   become: true
   become_user: "{{ consul_user }}"
-  command: "launchctl bootout gui/{{ uid.stdout }} {{ consul_launchctl_plist }}"
+  ansible.builtin.command: "launchctl bootout gui/{{ uid.stdout }} {{ consul_launchctl_plist }}"
   changed_when: false
   register: unload_consul_service
   # Code 113 is returned by launchctl for the error "Could not find service in domain for

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,9 @@
----
 collections:
   - name: ansible.utils
     version: 2.6.1
   - name: ansible.windows
     version: 1.13.0
+  - name: community.general
+    version: 8.1.0
+  - name: community.windows
+    version: 2.1.0

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -3,21 +3,21 @@
 - name: Save exsiting ACL master token
   block:
     - name: Read ACL master token from previously boostrapped server
-      command: "cat {{ consul_config_path }}/config.json"
+      ansible.builtin.command: "cat {{ consul_config_path }}/config.json"
       register: config_read
       no_log: true
       changed_when: false
       run_once: true
 
     - name: Save acl_master_token from existing configuration
-      set_fact:
+      ansible.builtin.set_fact:
         consul_acl_master_token: "{{ config_read.stdout | from_json | json_query(query) }}"
       vars:
         query: "acl.tokens.master"
       no_log: true
 
     - name: Save acl_initial_management from existing configuration if acl_master_token not found
-      set_fact:
+      ansible.builtin.set_fact:
         consul_acl_master_token: "{{ config_read.stdout | from_json | json_query(query) }}"
       vars:
         query: "acl.tokens.initial_management"
@@ -33,13 +33,13 @@
   block:
 
     - name: Generate ACL master token
-      command: "echo {{ lookup('password', '/dev/null length=32 chars=ascii_letters') | to_uuid }}"
+      ansible.builtin.command: "echo {{ lookup('password', '/dev/null length=32 chars=ascii_letters') | to_uuid }}"
       register: consul_acl_master_token_keygen
       run_once: true
       no_log: true
 
     - name: Save ACL master token
-      set_fact:
+      ansible.builtin.set_fact:
         consul_acl_master_token: "{{ consul_acl_master_token_keygen.stdout }}"
       no_log: true
 
@@ -49,7 +49,7 @@
     - consul_node_role == 'server'
 
 - name: Display ACL Master Token
-  debug:
+  ansible.builtin.debug:
     msg: "{{ consul_acl_master_token }}"
   run_once: true
   when:
@@ -59,14 +59,14 @@
 - name: Save existing ACL replication token
   block:
     - name: Read ACL master token from previously boostrapped server
-      command: "cat {{ consul_config_path }}/config.json"
+      ansible.builtin.command: "cat {{ consul_config_path }}/config.json"
       register: config_read
       no_log: true
       changed_when: false
       run_once: true
 
     - name: Save acl_replication_token from existing configuration
-      set_fact:
+      ansible.builtin.set_fact:
         consul_acl_replication_token: "{{ config_read.stdout | from_json | json_query(query) }}"
       vars:
         query: "acl.tokens.replication"
@@ -81,13 +81,13 @@
   block:
 
     - name: Generate ACL replication token
-      command: "echo {{ lookup('password', '/dev/null length=32 chars=ascii_letters') | to_uuid }}"
+      ansible.builtin.command: "echo {{ lookup('password', '/dev/null length=32 chars=ascii_letters') | to_uuid }}"
       register: consul_acl_replication_token_keygen
       no_log: true
       run_once: true
 
     - name: Save ACL replication token
-      set_fact:
+      ansible.builtin.set_fact:
         consul_acl_replication_token: "{{ consul_acl_replication_token_keygen.stdout }}"
       no_log: true
 
@@ -97,7 +97,7 @@
     - consul_node_role == 'server'
 
 - name: Create ACL policy configuration
-  template:
+  ansible.builtin.template:
     src: configd_50acl_policy.hcl.j2
     dest: "{{ consul_configd_path }}/50acl_policy.hcl"
     owner: "{{ consul_user }}"

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -112,7 +112,8 @@
 # Check for unzip binary
 
 - name: Check if unzip is installed on control host
-  ansible.builtin.shell: "command -v unzip -h >/dev/null 2>&1"
+  ansible.builtin.shell:
+    cmd: command -v unzip -h >/dev/null 2>&1
   become: false
   changed_when: false
   check_mode: false

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -2,7 +2,7 @@
 # File: asserts.yml - Asserts for this playbook
 
 - name: Define supported *nix distributions
-  set_fact:
+  ansible.builtin.set_fact:
     _consul_nix_distros:
       - 'RedHat'
       - 'CentOS'
@@ -22,56 +22,56 @@
       - 'MacOSX'
 
 - name: Check distribution compatibility
-  fail:
+  ansible.builtin.fail:
     msg: "{{ ansible_distribution }} is not currently supported by this role."
   when:
     - ansible_distribution not in _consul_nix_distros
     - ansible_os_family != 'Windows'
 
 - name: Check Photon version
-  fail:
+  ansible.builtin.fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution in ['VMware Photon OS']
     - ansible_distribution_version is version_compare(4, '<')
 
 - name: Check CentOS, Red Hat or Oracle Linux version
-  fail:
+  ansible.builtin.fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution in ['RedHat', 'CentOS', 'OracleLinux', 'Rocky', 'AlmaLinux']
     - ansible_distribution_version is version_compare(6, '<')
 
 - name: Check Debian version
-  fail:
+  ansible.builtin.fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "Debian"
     - (ansible_distribution_version != 'buster/sid') and (ansible_distribution_version is version_compare(8, '<'))
 
 - name: Check FreeBSD version
-  fail:
+  ansible.builtin.fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "FreeBSD"
     - ansible_distribution_version is version_compare(10, '<')
 
 - name: Check Ubuntu version
-  fail:
+  ansible.builtin.fail:
     msg: "{{ ansible_distribution_version }} is not a supported version."
   when:
     - ansible_distribution == "Ubuntu"
     - ansible_distribution_version is version_compare(13.04, '<')
 
 - name: Check specified ethernet interface
-  fail:
+  ansible.builtin.fail:
     msg: "The ethernet interface specified by consul_iface was not found."
   when:
     - ansible_os_family != 'Windows'
     - consul_iface not in ansible_interfaces
 
 - name: Check iptables on Red Hat, CentOS or Oracle Linux
-  fail:
+  ansible.builtin.fail:
     msg: "Use DNSmasq instead of iptables on {{ ansible_distribution }}."
   when:
     - consul_iptables_enable | bool
@@ -79,31 +79,31 @@
     - ansible_distribution_version is version_compare(6, '>=')
 
 - name: Check for both Dnsmasq and iptables enabled
-  fail:
+  ansible.builtin.fail:
     msg: "EONEORTHEOTHER: DNSmasq and iptables together is not supported."
   when:
     - consul_dnsmasq_enable | bool
     - consul_iptables_enable | bool
 
 - name: Check for iptables enabled but no recursors
-  fail:
+  ansible.builtin.fail:
     msg: "Recursors are required if iptables is enabled."
   when:
     - consul_iptables_enable | bool
     - consul_recursors | length == 0
 
 - name: Check consul_group_name is included in groups
-  fail:
+  ansible.builtin.fail:
     msg: "consul_group_name must be included in groups."
   when: consul_group_name not in groups
 
 - name: Fail if more than one bootstrap server is defined
-  fail:
+  ansible.builtin.fail:
     msg: "You can not define more than one bootstrap server."
   when: _consul_bootstrap_servers | length > 1
 
 - name: Fail if a bootstrap server is defined and bootstrap_expect is true
-  fail:
+  ansible.builtin.fail:
     msg: "Can't use a bootstrap server and bootstrap_expect at the same time."
   when:
     - _consul_bootstrap_servers | length > 0
@@ -112,7 +112,7 @@
 # Check for unzip binary
 
 - name: Check if unzip is installed on control host
-  shell: "command -v unzip -h >/dev/null 2>&1"
+  ansible.builtin.shell: "command -v unzip -h >/dev/null 2>&1"
   become: false
   changed_when: false
   check_mode: false
@@ -124,6 +124,6 @@
     ansible_become: false
 
 - name: Install remotely if unzip is not installed on control host
-  set_fact:
+  ansible.builtin.set_fact:
     consul_install_remotely: true
   when: is_unzip_installed is failed

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,7 +2,7 @@
 # File: config.yml - Consul configuration tasks
 
 - name: Create configuration
-  copy:
+  ansible.builtin.copy:
     dest: "{{ config_item.dest }}"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
@@ -28,7 +28,7 @@
     - restart consul
 
 - name: Create custom configuration
-  copy:
+  ansible.builtin.copy:
     dest: "{{ consul_configd_path }}/50custom.json"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
@@ -39,6 +39,6 @@
     - restart consul
 
 - name: Set fact list with custom configuration file
-  set_fact:
+  ansible.builtin.set_fact:
     managed_files: "{{ managed_files |default([]) }} + \
       [ '{{ consul_configd_path }}/50custom.json' ]"

--- a/tasks/config_windows.yml
+++ b/tasks/config_windows.yml
@@ -2,7 +2,7 @@
 # File: config_windows.yml - Consul configuration tasks for Windows
 
 - name: Create configuration
-  win_copy:
+  ansible.windows.win_copy:
     dest: "{{ config_item.dest }}"
     content: "{{ lookup('template', consul_config_template_path, convert_data=True) | to_nice_json }}"
   with_items:
@@ -25,7 +25,7 @@
     - restart consul
 
 - name: Create custom configuration
-  win_copy:
+  ansible.windows.win_copy:
     dest: "{{ consul_configd_path }}/50custom.json"
     content: "{{ lookup('template', 'templates/configd_50custom.json.j2', convert_data=True) | to_nice_json }}"
   when: consul_config_custom is defined
@@ -33,12 +33,12 @@
     - restart consul
 
 - name: Get Windows path for custom configuration file
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ consul_configd_path }}/50custom.json"
   register: custom_config_win_path
 
 - name: Set fact list with custom configuration file
-  set_fact:
+  ansible.builtin.set_fact:
     managed_files: "{{ managed_files |default([]) }} + \
       [ '{{ custom_config_win_path.results[0].stat.path }}' ]"
   when: custom_config_win_path.stat.exists

--- a/tasks/dirs.yml
+++ b/tasks/dirs.yml
@@ -4,7 +4,7 @@
 - name: Create directories
   block:
     - name: Configuration and data directories
-      file:
+      ansible.builtin.file:
         dest: "{{ dir_item }}"
         state: directory
         owner: "{{ consul_user }}"
@@ -17,7 +17,7 @@
       loop_control:
         loop_var: dir_item
     - name: Run directory
-      file:
+      ansible.builtin.file:
         dest: "{{ consul_run_path }}"
         state: directory
         owner: "{{ consul_user }}"
@@ -28,7 +28,7 @@
   when: ansible_os_family != 'Windows'
 
 - name: Create log directory
-  file:
+  ansible.builtin.file:
     dest: "{{ consul_log_path }}"
     state: directory
     owner: "{{ consul_user }}"
@@ -40,7 +40,7 @@
     - not consul_configure_syslogd | bool
 
 - name: Create log directory
-  file:
+  ansible.builtin.file:
     dest: "{{ log_item }}"
     state: directory
     owner: "{{ syslog_user }}"
@@ -56,7 +56,7 @@
     - consul_configure_syslogd | bool
 
 - name: Verify binary path
-  file:
+  ansible.builtin.file:
     path: "{{ consul_bin_path }}"
     state: directory
     owner: root
@@ -71,7 +71,7 @@
     - not consul_install_from_repo | bool
 
 - name: Create directories on Windows
-  win_file:
+  ansible.windows.win_file:
     dest: "{{ dir_item }}"
     state: directory
   with_items:

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -2,14 +2,14 @@
 # File: dnsmasq.yml - Dnsmasq tasks for Consul
 
 - name: Install Dnsmasq package
-  package:
+  ansible.builtin.package:
     name: "{{ dnsmasq_package }}"
     state: present
   become: true
   tags: dnsmasq, installation
 
 - name: Create Dnsmasq configuration directory
-  file:
+  ansible.builtin.file:
     path: /usr/local/etc/dnsmasq.d
     state: directory
     owner: root
@@ -20,7 +20,7 @@
   tags: dnsmasq
 
 - name: Include Dnsmasq configuration directory
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /usr/local/etc/dnsmasq.conf
     line: 'conf-dir=/usr/local/etc/dnsmasq.d/,*.conf'
   become: true
@@ -29,7 +29,7 @@
   tags: dnsmasq
 
 - name: Create Dnsmasq configuration
-  template:
+  ansible.builtin.template:
     src: dnsmasq-10-consul.j2
     dest: "{{ dnsmasq_item.dest }}"
     owner: root
@@ -50,12 +50,12 @@
   block:
 
     - name: Check if systemd-resolved service exists
-      stat:
+      ansible.builtin.stat:
         path: /lib/systemd/system/systemd-resolved.service
       register: systemd_resolved_service
 
     - name: Disable systemd-resolved service
-      service:
+      ansible.builtin.service:
         name: systemd-resolved
         enabled: false
         state: stopped
@@ -65,19 +65,19 @@
       when: systemd_resolved_service.stat.exists
 
     - name: Check if resolv.conf is pointing to systemd-resolved
-      stat:
+      ansible.builtin.stat:
         path: /etc/resolv.conf
       register: resolv_dot_conf
 
     - name: Configure resolv.conf for dnsmasq
       block:
         - name: Remove resolv.conf association with systemd-resolved
-          file:
+          ansible.builtin.file:
             path: /etc/resolv.conf
             state: absent
 
         - name: Add a nameserver entry poining to localhost for dnsmasq
-          lineinfile:
+          ansible.builtin.lineinfile:
             path: /etc/resolv.conf
             regexp: "^nameserver 127.0.0.1"
             line: "nameserver 127.0.0.1"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,14 +2,14 @@
 # File: install.yml - package installation tasks for Consul
 
 - name: Install OS packages
-  package:
+  ansible.builtin.package:
     name: "{{ consul_os_packages }}"
     state: present
   tags: installation
   when: not ansible_facts['os_family'] == "VMware Photon OS" and (consul_os_packages | length > 0)
 
 - name: Install OS packages
-  command: "tdnf install -y {{ package_item }}"
+  ansible.builtin.command: "tdnf install -y {{ package_item }}"
   with_items: "{{ consul_os_packages }}"
   loop_control:
     loop_var: package_item
@@ -17,14 +17,14 @@
   when: ansible_facts['os_family'] == "VMware Photon OS"
 
 - name: Update Alpine Package Manager (APK)
-  apk:
+  community.general.apk:
     update_cache: true
   run_once: true
   when: ansible_os_family == "Alpine"
   delegate_to: 127.0.0.1
 
 - name: Read package checksum file
-  stat:
+  ansible.builtin.stat:
     path: "{{ role_path }}/files/consul_{{ consul_version }}_SHA256SUMS"
   become: false
   vars:
@@ -35,7 +35,7 @@
   delegate_to: 127.0.0.1
 
 - name: Download package checksum file
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ consul_checksum_file_url }}"
     dest: "{{ role_path }}/files/consul_{{ consul_version }}_SHA256SUMS"
   become: false
@@ -47,7 +47,7 @@
   delegate_to: 127.0.0.1
 
 - name: Read package checksum
-  shell: grep "{{ consul_pkg }}" "{{ role_path }}/files/consul_{{ consul_version }}_SHA256SUMS" | awk '{print $1}'
+  ansible.builtin.shell: grep "{{ consul_pkg }}" "{{ role_path }}/files/consul_{{ consul_version }}_SHA256SUMS" | awk '{print $1}'
   become: false
   vars:
     ansible_become: false
@@ -60,7 +60,7 @@
   delegate_to: 127.0.0.1
 
 - name: Check Consul package file
-  stat:
+  ansible.builtin.stat:
     path: "{{ role_path }}/files/{{ consul_pkg }}"
   become: false
   vars:
@@ -71,7 +71,7 @@
   delegate_to: 127.0.0.1
 
 - name: Download Consul package
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ consul_zip_url }}"
     dest: "{{ role_path }}/files/{{ consul_pkg }}"
     checksum: "sha256:{{ consul_sha256.stdout }}"
@@ -86,7 +86,7 @@
   ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Create Temporary Directory for Extraction
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
     prefix: ansible-consul.
   become: false
@@ -100,7 +100,7 @@
 - name: Unarchive and install Consul
   block:
     - name: Unarchive Consul package
-      unarchive:
+      ansible.builtin.unarchive:
         src: "{{ role_path }}/files/{{ consul_pkg }}"
         dest: "{{ install_temp.path }}/"
         creates: "{{ install_temp.path }}/consul"
@@ -115,7 +115,7 @@
       ignore_errors: "{{ ansible_check_mode }}"
 
     - name: Install Consul
-      copy:
+      ansible.builtin.copy:
         src: "{{ install_temp.path }}/consul"
         dest: "{{ consul_bin_path }}/consul"
         owner: "{{ consul_user }}"
@@ -128,7 +128,7 @@
       ignore_errors: "{{ ansible_check_mode }}"
   always:
     - name: Cleanup
-      file:
+      ansible.builtin.file:
         path: "{{ install_temp.path }}"
         state: "absent"
       become: false

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -2,7 +2,7 @@
 # File: install_linux_repo.yml - package installation tasks for Consul
 
 - name: Install OS packages
-  package:
+  ansible.builtin.package:
     name: "{{ consul_repo_prerequisites }}"
     state: present
   become: true
@@ -10,16 +10,16 @@
   tags: installation
 
 - name: Gather the package facts
-  package_facts:
+  ansible.builtin.package_facts:
     manager: auto
 
 - name: Clean up previous consul data
   block:
     - name: Populate service facts
-      service_facts:
+      ansible.builtin.service_facts:
 
     - name: Stop service consul, if running
-      service:
+      ansible.builtin.service:
         name: consul
         state: stopped
         # Needed to force SysV service manager on Docker for Molecule tests
@@ -27,7 +27,7 @@
       when: ansible_facts.services | join is match('.*consul.*')
 
     - name: Remove consul service unit files from previous installation
-      file:
+      ansible.builtin.file:
         path: "{{ service_unit_item }}"
         state: absent
       loop:
@@ -37,7 +37,7 @@
         loop_var: service_unit_item
 
     - name: Remove the user 'consul'
-      user:
+      ansible.builtin.user:
         name: consul
         state: absent
         remove: true
@@ -48,7 +48,7 @@
 - name: Install repository
   block:
     - name: Add Redhat/CentOS/Fedora/Amazon Linux repository
-      command: "yum-config-manager --add-repo {{ consul_repo_url }}"
+      ansible.builtin.command: "yum-config-manager --add-repo {{ consul_repo_url }}"
       args:
         creates: /etc/yum.repos.d/hashicorp.repo
       when: >
@@ -61,13 +61,13 @@
 
 
     - name: Add an Apt signing key, uses whichever key is at the URL
-      apt_key:
+      ansible.builtin.apt_key:
         url: "{{ consul_repo_url }}/gpg"
         state: present
       when: "ansible_os_family|lower == 'debian'"
 
     - name: Add Debian/Ubuntu Linux repository
-      apt_repository:
+      ansible.builtin.apt_repository:
         repo: "deb {{ consul_repo_url }} {{ ansible_distribution_release }} main"
         state: present
         update_cache: true
@@ -77,13 +77,13 @@
   become: true
 
 - name: Install consul package
-  package:
+  ansible.builtin.package:
     name: "consul{{ '=' if ansible_pkg_mgr == 'apt' else '-' }}{{ consul_version }}"
     state: present
   become: true
 
 - name: Create a directory /etc/systemd/system/consul.service.d
-  file:
+  ansible.builtin.file:
     path: /etc/systemd/system/consul.service.d
     state: directory
     mode: '0755'
@@ -94,7 +94,7 @@
   when: ansible_service_mgr == "systemd"
 
 - name: Override systemd service params
-  template:
+  ansible.builtin.template:
     src: consul_systemd_service.override.j2
     dest: /etc/systemd/system/consul.service.d/override.conf
     owner: root
@@ -110,10 +110,10 @@
     - consul_install_from_repo | bool
 
 - name: Flush handlers
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers
 
 - name: As, this role work with json conf file only - delete file /etc/consul.d/consul.hcl
-  file:
+  ansible.builtin.file:
     path: /etc/consul.d/consul.hcl
     state: absent
   become: true

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -2,13 +2,13 @@
 # File: install_remote.yml - package installation tasks for Consul
 
 - name: Install OS packages
-  package:
+  ansible.builtin.package:
     name: "{{ consul_os_packages }}"
     state: present
   tags: installation
 
 - name: Validate remote Consul directory
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
     prefix: ansible-consul.
   register: consul_temp_dir
@@ -16,14 +16,14 @@
 - name: Download and unarchive Consul
   block:
     - name: Read Consul package checksum file
-      stat:
+      ansible.builtin.stat:
         path: "{{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
       register: consul_checksum
       changed_when: false
       tags: installation
 
     - name: Download Consul package checksum file
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ consul_checksum_file_url }}"
         dest: "{{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
         validate_certs: false
@@ -31,7 +31,7 @@
       when: not consul_checksum.stat.exists | bool
 
     - name: Read Consul package checksum
-      shell: "grep {{ consul_pkg }} {{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
+      ansible.builtin.shell: "grep {{ consul_pkg }} {{ consul_temp_dir.path }}/consul_{{ consul_version }}_SHA256SUMS"
       register: consul_sha256
       changed_when: false
       tags:
@@ -39,7 +39,7 @@
         - skip_ansible_lint
 
     - name: Download Consul
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ consul_zip_url }}"
         dest: "{{ consul_temp_dir.path }}/{{ consul_pkg }}"
         checksum: "sha256:{{ consul_sha256.stdout.split(' ')|first }}"
@@ -48,7 +48,7 @@
       tags: installation
 
     - name: Unarchive Consul and install binary
-      unarchive:
+      ansible.builtin.unarchive:
         remote_src: true
         src: "{{ consul_temp_dir.path }}/{{ consul_pkg }}"
         dest: "{{ consul_bin_path }}"
@@ -63,7 +63,7 @@
       tags: installation
   always:
     - name: Cleanup
-      file:
+      ansible.builtin.file:
         path: "{{ consul_temp_dir.path }}"
         state: absent
       tags: installation

--- a/tasks/install_windows.yml
+++ b/tasks/install_windows.yml
@@ -2,7 +2,7 @@
 # File: install_remote.yml - package installation tasks for Consul
 
 - name: Verify TLS1.2 is used
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKLM:\SOFTWARE\Microsoft\.NETFramework\v4.0.30319
     name: SchUseStrongCrypto
     data: 1
@@ -22,7 +22,7 @@
     - win_consul_service.services[0].state == "started"
 
 - name: Create temporary directory to download Consul
-  win_tempfile:
+  ansible.windows.win_tempfile:
     state: directory
     prefix: ansible-consul.
   register: consul_temp_dir
@@ -30,51 +30,51 @@
 - name: Download and unarchive Consul
   block:
     - name: Read Consul package checksum file
-      win_stat:
+      ansible.windows.win_stat:
         path: "{{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
       register: consul_checksum
       tags: installation
 
     - name: Download Consul package checksum file
-      win_get_url:
+      ansible.windows.win_get_url:
         url: "{{ consul_checksum_file_url }}"
         dest: "{{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
       tags: installation
       when: not consul_checksum.stat.exists | bool
 
     - name: Read Consul package checksum
-      win_shell: "findstr {{ consul_pkg }} {{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
+      ansible.windows.win_shell: "findstr {{ consul_pkg }} {{ consul_temp_dir.path }}\\consul_{{ consul_version }}_SHA256SUMS"
       args:
         chdir: "{{ consul_temp_dir.path }}"
       register: consul_pkg_checksum
       tags: installation
 
     - name: Download Consul
-      win_get_url:
+      ansible.windows.win_get_url:
         url: "{{ consul_zip_url }}"
         dest: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
       tags: installation
 
     - name: Calculate checksum
-      win_stat:
+      ansible.windows.win_stat:
         path: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
         checksum_algorithm: sha256
       register: consul_pkg_hash
       tags: installation
 
     - name: Compare checksum to hashfile
-      fail:
+      ansible.builtin.fail:
         msg: "Checksum {{ consul_pkg_checksum.stdout.split(' ') | first }} did not match calculated SHA256 {{ consul_pkg_hash.stat.checksum }}!"
       when: consul_pkg_hash.stat.checksum != (consul_pkg_checksum.stdout.split(' ') | first)
 
     - name: Unarchive Consul and install binary
-      win_unzip:
+      community.windows.win_unzip:
         src: "{{ consul_temp_dir.path }}\\{{ consul_pkg }}"
         dest: "{{ consul_bin_path }}"
       tags: installation
   always:
     - name: Cleanup
-      win_file:
+      ansible.windows.win_file:
         path: "{{ consul_temp_dir.path }}"
         state: absent
       tags: installation

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -2,11 +2,11 @@
 # File: iptables.yml - iptables tasks for Consul
 
 - name: Install iptables
-  apt:
+  ansible.builtin.apt:
     name: iptables
 
 - name: Redirect local DNS (1/4)
-  iptables:
+  ansible.builtin.iptables:
     table: nat
     chain: PREROUTING
     protocol: udp
@@ -16,7 +16,7 @@
     to_ports: 8600
 
 - name: Redirect local DNS (2/4)
-  iptables:
+  ansible.builtin.iptables:
     table: nat
     chain: PREROUTING
     protocol: tcp
@@ -26,7 +26,7 @@
     to_ports: 8600
 
 - name: Redirect local DNS (3/4)
-  iptables:
+  ansible.builtin.iptables:
     table: nat
     chain: OUTPUT
     protocol: udp
@@ -37,7 +37,7 @@
     destination: localhost
 
 - name: Redirect local DNS (4/4)
-  iptables:
+  ansible.builtin.iptables:
     table: nat
     chain: OUTPUT
     protocol: tcp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,8 @@
       when: is_virtualenv is defined
 
 - name: Include checks/asserts
-  ansible.builtin.import_tasks: asserts.yml
+  ansible.builtin.import_tasks:
+    file: asserts.yml
 
 - name: Include OS-specific variables
   ansible.builtin.include_vars: "{{ vars_file_item }}"
@@ -47,18 +48,21 @@
 # Tasks for all *NIX operating systems
 # -----------------------------------------------------------------------
 - name: Include NIX tasks
-  ansible.builtin.include_tasks: nix.yml
+  ansible.builtin.include_tasks:
+    file: nix.yml
   when: ansible_os_family != 'Windows'
 
 # -----------------------------------------------------------------------
 # Tasks for Windows
 # -----------------------------------------------------------------------
 - name: Include Windows tasks
-  ansible.builtin.include_tasks: windows.yml
+  ansible.builtin.include_tasks:
+    file: windows.yml
   when: ansible_os_family == 'Windows'
 
 - name: Include services management
-  ansible.builtin.import_tasks: services.yml
+  ansible.builtin.import_tasks:
+    file: services.yml
   when: consul_services is defined and consul_services|length>0
   tags:
     - consul_services

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # File: main.yml - Main tasks for Consul
 - name: Looking up latest version of Consul
-  set_fact:
+  ansible.builtin.set_fact:
     consul_version: "{{ (lookup('url', 'https://api.github.com/repos/hashicorp/consul/releases/latest', split_lines=False) |
                     from_json).get('tag_name') | replace('v', '') }}"
   when: 'consul_version == "latest"'
@@ -10,7 +10,7 @@
   when: consul_install_dependencies | bool
   block:
     - name: Install netaddr dependency on controlling host (with --user)
-      pip:
+      ansible.builtin.pip:
         name: netaddr
         extra_args: --user
       delegate_to: 127.0.0.1
@@ -21,7 +21,7 @@
       when: not is_virtualenv or is_virtualenv == None
 
     - name: Install netaddr dependency on controlling host (virtualenv)
-      pip:
+      ansible.builtin.pip:
         name: netaddr
       delegate_to: 127.0.0.1
       become: false
@@ -31,10 +31,10 @@
       when: is_virtualenv is defined
 
 - name: Include checks/asserts
-  import_tasks: asserts.yml
+  ansible.builtin.import_tasks: asserts.yml
 
 - name: Include OS-specific variables
-  include_vars: "{{ vars_file_item }}"
+  ansible.builtin.include_vars: "{{ vars_file_item }}"
   with_first_found:
     - files:
         - '{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml'
@@ -47,21 +47,21 @@
 # Tasks for all *NIX operating systems
 # -----------------------------------------------------------------------
 - name: Include NIX tasks
-  include_tasks: nix.yml
+  ansible.builtin.include_tasks: nix.yml
   when: ansible_os_family != 'Windows'
 
 # -----------------------------------------------------------------------
 # Tasks for Windows
 # -----------------------------------------------------------------------
 - name: Include Windows tasks
-  include_tasks: windows.yml
+  ansible.builtin.include_tasks: windows.yml
   when: ansible_os_family == 'Windows'
 
 - name: Include services management
-  import_tasks: services.yml
+  ansible.builtin.import_tasks: services.yml
   when: consul_services is defined and consul_services|length>0
   tags:
     - consul_services
 
 - name: Flush handlers
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -29,14 +29,17 @@
   tags: always
 
 - name: Include user and group settings
-  ansible.builtin.import_tasks: user_group.yml
+  ansible.builtin.import_tasks:
+    file: user_group.yml
 
 - name: Install OS packages and consul - from the repository
-  ansible.builtin.include_tasks: install_linux_repo.yml
+  ansible.builtin.include_tasks:
+    file: install_linux_repo.yml
   when: consul_install_from_repo | bool
 
 - name: Include directory settings
-  ansible.builtin.import_tasks: dirs.yml
+  ansible.builtin.import_tasks:
+    file: dirs.yml
 
 - name: Check for existing Consul binary
   ansible.builtin.stat:
@@ -60,14 +63,16 @@
       consul_installed_version.stdout_lines[0] != _consul_expected_version_string }}"
 
 - name: Install OS packages and consul - locally
-  ansible.builtin.include_tasks: install.yml
+  ansible.builtin.include_tasks:
+    file: install.yml
   when:
     - consul_install_binary | bool
     - not consul_install_remotely | bool
     - not consul_install_from_repo | bool
 
 - name: Install OS packages and consul - remotely
-  ansible.builtin.include_tasks: install_remote.yml
+  ansible.builtin.include_tasks:
+    file: install_remote.yml
   when:
     - consul_install_binary | bool
     - consul_install_remotely | bool
@@ -174,18 +179,22 @@
       changed_when: false
 
 - name: Create ACL configuration
-  ansible.builtin.include_tasks: acl.yml
+  ansible.builtin.include_tasks:
+    file: acl.yml
   when: consul_acl_enable | bool
 
 - name: Create Consul configuration
-  ansible.builtin.import_tasks: config.yml
+  ansible.builtin.import_tasks:
+    file: config.yml
 
 - name: Create TLS configuration
-  ansible.builtin.include_tasks: tls.yml
+  ansible.builtin.include_tasks:
+    file: tls.yml
   when: consul_tls_enable | bool
 
 - name: Create syslog configuration
-  ansible.builtin.import_tasks: syslog.yml
+  ansible.builtin.import_tasks:
+    file: syslog.yml
 
 - name: Create BSD init script
   ansible.builtin.template:
@@ -281,14 +290,16 @@
     - ansible_os_family == "Solaris"
   tags: skip_ansible_lint
 - name: Import smf script
-  ansible.builtin.shell: "svcadm refresh consul"
+  ansible.builtin.shell:
+    cmd: svcadm refresh consul
   when:
     - smfmanifest is changed
     - ansible_os_family == "Solaris"
   tags: skip_ansible_lint
 
 - name: Enable Consul Snapshots on servers
-  ansible.builtin.include_tasks: snapshot.yml
+  ansible.builtin.include_tasks:
+    file: snapshot.yml
   when:
     - ansible_service_mgr == "systemd"
     - not ansible_os_family == "FreeBSD"
@@ -327,7 +338,8 @@
         mode: 0600
 
     - name: Configure iptables
-      ansible.builtin.include_tasks: ../tasks/iptables.yml
+      ansible.builtin.include_tasks:
+        file: ../tasks/iptables.yml
       when: consul_iptables_enable | bool
 
   when:
@@ -335,5 +347,6 @@
     - not ansible_os_family == "Darwin"
 
 - name: Configure dnsmasq
-  ansible.builtin.include_tasks: ../tasks/dnsmasq.yml
+  ansible.builtin.include_tasks:
+    file: ../tasks/dnsmasq.yml
   when: consul_dnsmasq_enable | bool

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -3,7 +3,7 @@
 # 'delegate_facts' is currently rather buggy in Ansible so this might not
 # always work. Hence 'consul_gather_server_facts' defaults to 'no'.
 - name: Gather facts from other servers
-  setup:
+  ansible.builtin.setup:
   delegate_to: "{{ host_item }}"
   delegate_facts: true
   with_items: "{{ consul_servers | difference(play_hosts) }}"
@@ -14,7 +14,7 @@
   when: consul_gather_server_facts | bool
 
 - name: Expose advertise_address(_wan) datacenter and node_role as facts
-  set_fact:
+  ansible.builtin.set_fact:
     consul_advertise_address_wan: "{{ consul_advertise_address_wan }}"
     consul_advertise_address: "{{ consul_advertise_address }}"
     consul_bind_address: "{{ consul_bind_address }}"
@@ -22,30 +22,30 @@
     consul_node_role: "{{ consul_node_role }}"
 
 - name: Read bootstrapped state
-  stat:
+  ansible.builtin.stat:
     path: "{{ consul_bootstrap_state }}"
   register: bootstrap_state
   ignore_errors: true
   tags: always
 
 - name: Include user and group settings
-  import_tasks: user_group.yml
+  ansible.builtin.import_tasks: user_group.yml
 
 - name: Install OS packages and consul - from the repository
-  include_tasks: install_linux_repo.yml
+  ansible.builtin.include_tasks: install_linux_repo.yml
   when: consul_install_from_repo | bool
 
 - name: Include directory settings
-  import_tasks: dirs.yml
+  ansible.builtin.import_tasks: dirs.yml
 
 - name: Check for existing Consul binary
-  stat:
+  ansible.builtin.stat:
     path: "{{ consul_binary }}"
   register: consul_binary_installed
   when: not consul_force_install
 
 - name: Get current Consul version
-  command: "{{ consul_binary }} --version"
+  ansible.builtin.command: "{{ consul_binary }} --version"
   check_mode: false
   changed_when: false
   when:
@@ -54,20 +54,20 @@
   register: consul_installed_version
 
 - name: Calculate whether to install consul binary
-  set_fact:
+  ansible.builtin.set_fact:
     consul_install_binary: "{{ consul_force_install or \
       not consul_binary_installed.stat.exists or \
       consul_installed_version.stdout_lines[0] != _consul_expected_version_string }}"
 
 - name: Install OS packages and consul - locally
-  include_tasks: install.yml
+  ansible.builtin.include_tasks: install.yml
   when:
     - consul_install_binary | bool
     - not consul_install_remotely | bool
     - not consul_install_from_repo | bool
 
 - name: Install OS packages and consul - remotely
-  include_tasks: install_remote.yml
+  ansible.builtin.include_tasks: install_remote.yml
   when:
     - consul_install_binary | bool
     - consul_install_remotely | bool
@@ -79,18 +79,18 @@
     - name: Save existing gossip encryption key
       block:
         - name: Check for gossip encryption key on previously boostrapped server
-          slurp:
+          ansible.builtin.slurp:
             src: "{{ consul_config_path }}/config.json"
           register: consul_config_b64
           ignore_errors: true
 
         - name: Deserialize existing configuration
-          set_fact:
+          ansible.builtin.set_fact:
             consul_config: "{{ consul_config_b64.content | b64decode | from_json }}"
           when: consul_config_b64.content is defined
 
         - name: Save gossip encryption key from existing configuration
-          set_fact:
+          ansible.builtin.set_fact:
             consul_raw_key: "{{ consul_config.encrypt }}"
           no_log: true
           when: consul_config is defined
@@ -102,7 +102,7 @@
 
     - name: Create temporary file for raw gossip encryption key
       delegate_to: localhost
-      tempfile:
+      ansible.builtin.tempfile:
         suffix: ".key"
       become: false
       vars:
@@ -113,7 +113,7 @@
 
     # Key provided by extra vars or the above block
     - name: Write gossip encryption key locally for use with new servers
-      copy:
+      ansible.builtin.copy:
         content: "{{ consul_raw_key }}"
         dest: "{{ consul_raw_key_file.path }}"
         mode: 0600
@@ -133,17 +133,17 @@
       block:
         - name: Create temporary file to receive gossip encryption key
           become: false
-          tempfile:
+          ansible.builtin.tempfile:
             state: file
           register: gossip_key_tempfile
 
         - name: Generate gossip encryption key
-          shell: "PATH={{ consul_bin_path }}:$PATH consul keygen > {{ gossip_key_tempfile.path }}"
+          ansible.builtin.shell: "PATH={{ consul_bin_path }}:$PATH consul keygen > {{ gossip_key_tempfile.path }}"
           register: consul_keygen
 
         - name: Fetch key locally to share with other nodes
           become: false
-          fetch:
+          ansible.builtin.fetch:
             src: "{{ gossip_key_tempfile.path }}"
             dest: "{{ consul_raw_key_file.path }}"
             flat: true
@@ -151,19 +151,19 @@
       always:
         - name: Clean up temporary file
           become: false
-          file:
+          ansible.builtin.file:
             path: "{{ gossip_key_tempfile.path }}"
             state: absent
           when: gossip_key_tempfile is defined
 
     - name: Read gossip encryption key for servers that require it
-      set_fact:
+      ansible.builtin.set_fact:
         consul_raw_key: "{{ lookup('file', consul_raw_key_file.path) }}"
       no_log: true
       when: consul_raw_key is not defined
 
     - name: Delete gossip encryption key file
-      file:
+      ansible.builtin.file:
         path: "{{ consul_raw_key_file.path }}"
         state: absent
       become: false
@@ -174,21 +174,21 @@
       changed_when: false
 
 - name: Create ACL configuration
-  include_tasks: acl.yml
+  ansible.builtin.include_tasks: acl.yml
   when: consul_acl_enable | bool
 
 - name: Create Consul configuration
-  import_tasks: config.yml
+  ansible.builtin.import_tasks: config.yml
 
 - name: Create TLS configuration
-  include_tasks: tls.yml
+  ansible.builtin.include_tasks: tls.yml
   when: consul_tls_enable | bool
 
 - name: Create syslog configuration
-  import_tasks: syslog.yml
+  ansible.builtin.import_tasks: syslog.yml
 
 - name: Create BSD init script
-  template:
+  ansible.builtin.template:
     src: consul_bsdinit.j2
     dest: /etc/rc.d/consul
     owner: root
@@ -197,7 +197,7 @@
   when: ansible_os_family == "FreeBSD"
 
 - name: Create SYSV init script
-  template:
+  ansible.builtin.template:
     src: consul_sysvinit.j2
     dest: /etc/init.d/consul
     owner: root
@@ -211,7 +211,7 @@
     - not ansible_os_family == "Darwin"
 
 - name: Create Debian init script
-  template:
+  ansible.builtin.template:
     src: consul_debianinit.j2
     dest: /etc/init.d/consul
     owner: root
@@ -225,7 +225,7 @@
     - not ansible_os_family == "Darwin"
 
 - name: Create systemd script
-  template:
+  ansible.builtin.template:
     src: consul_systemd.service.j2
     dest: "{{ consul_systemd_unit_path }}/consul.service"
     owner: root
@@ -241,12 +241,12 @@
     - not consul_install_from_repo | bool
 
 - name: Reload systemd
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: true
   when: systemd_unit is changed
 
 - name: Enable consul at startup (systemd)
-  systemd:
+  ansible.builtin.systemd:
     name: consul
     enabled: true
   when:
@@ -256,7 +256,7 @@
     - not ansible_os_family == "Darwin"
 
 - name: Create launchctl plist file
-  template:
+  ansible.builtin.template:
     src: "consul_launchctl.plist.j2"
     dest: "{{ consul_launchctl_plist }}"
     mode: "0644"
@@ -265,7 +265,7 @@
   notify: restart consul
 
 - name: Create smf manifest
-  template:
+  ansible.builtin.template:
     src: consul_smf_manifest.j2
     dest: "{{ consul_smf_manifest }}"
     owner: root
@@ -275,20 +275,20 @@
   register: smfmanifest
 
 - name: Import smf manifest
-  shell: "svccfg import {{ consul_smf_manifest }}"
+  ansible.builtin.shell: "svccfg import {{ consul_smf_manifest }}"
   when:
     - smfmanifest is changed
     - ansible_os_family == "Solaris"
   tags: skip_ansible_lint
 - name: Import smf script
-  shell: "svcadm refresh consul"
+  ansible.builtin.shell: "svcadm refresh consul"
   when:
     - smfmanifest is changed
     - ansible_os_family == "Solaris"
   tags: skip_ansible_lint
 
 - name: Enable Consul Snapshots on servers
-  include_tasks: snapshot.yml
+  ansible.builtin.include_tasks: snapshot.yml
   when:
     - ansible_service_mgr == "systemd"
     - not ansible_os_family == "FreeBSD"
@@ -300,7 +300,7 @@
   block:
 
     - name: Start Consul
-      service:
+      ansible.builtin.service:
         name: consul
         state: started
         enabled: true
@@ -308,26 +308,26 @@
         use: "{{ ansible_service_mgr }}"
 
     - name: Check Consul HTTP API (via TCP socket)
-      wait_for:
+      ansible.builtin.wait_for:
         delay: 15
         port: "{{ consul_ports.http|int }}"
         host: "{{ consul_addresses.http }}"
       when: (consul_ports.http|int > -1) and (consul_addresses.http|ansible.utils.ipaddr)
 
     - name: Check Consul HTTP API (via unix socket)
-      wait_for:
+      ansible.builtin.wait_for:
         delay: 15
         path: "{{ consul_addresses.http | replace('unix://', '', 1) }}"
       when: consul_addresses.http is match("unix://*")
 
     - name: Create bootstrapped state file
-      file:
+      ansible.builtin.file:
         dest: "{{ consul_bootstrap_state }}"
         state: touch
         mode: 0600
 
     - name: Configure iptables
-      include_tasks: ../tasks/iptables.yml
+      ansible.builtin.include_tasks: ../tasks/iptables.yml
       when: consul_iptables_enable | bool
 
   when:
@@ -335,5 +335,5 @@
     - not ansible_os_family == "Darwin"
 
 - name: Configure dnsmasq
-  include_tasks: ../tasks/dnsmasq.yml
+  ansible.builtin.include_tasks: ../tasks/dnsmasq.yml
   when: consul_dnsmasq_enable | bool

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -250,12 +250,12 @@
     - not consul_install_from_repo | bool
 
 - name: Reload systemd
-  ansible.builtin.systemd:
+  ansible.builtin.systemd_service:
     daemon_reload: true
   when: systemd_unit is changed
 
 - name: Enable consul at startup (systemd)
-  ansible.builtin.systemd:
+  ansible.builtin.systemd_service:
     name: consul
     enabled: true
   when:

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -2,7 +2,7 @@
 ## File: services.yml - services configuration
 
 - name: Configure consul services
-  template:
+  ansible.builtin.template:
     dest: "{{ consul_configd_path }}/service_{{ service_item.name }}.json"
     src: service.json.j2
     owner: "{{ consul_user }}"
@@ -15,38 +15,38 @@
     - restart consul
 
 - name: Get the list of service config files
-  find:
+  ansible.builtin.find:
     paths: "{{ consul_configd_path }}"
     file_type: file
   register: services_enabled_unix
   when: ansible_os_family != 'Windows'
 
 - name: Get the list of service config files [Windows]
-  win_find:
+  ansible.windows.win_find:
     paths: "{{ consul_configd_path }}"
     file_type: file
   register: services_enabled_windows
   when: ansible_os_family == 'Windows'
 
 - name: Set var for enabled services
-  set_fact:
+  ansible.builtin.set_fact:
     services_enabled_files: "{{ services_enabled_unix['files'] }}"
   when: ansible_os_family != 'Windows'
 
 - name: Set var for enabled services [Windows]
-  set_fact:
+  ansible.builtin.set_fact:
     services_enabled_files: "{{ services_enabled_windows['files'] }}"
   when: ansible_os_family == 'Windows'
 
 - name: Set fact with list of existing configuration files
-  set_fact:
+  ansible.builtin.set_fact:
     list_current_service_config: "{{ list_current_service_config |default([]) + [ config_file_item.path ] }}"
   with_items: "{{ services_enabled_files }}"
   loop_control:
     loop_var: config_file_item
 
 - name: Set fact with list of services we manage
-  set_fact:
+  ansible.builtin.set_fact:
     managed_files: "{{ managed_files |default([]) }} + \
     [ '{{ consul_configd_path }}/service_{{ service_item.name }}.json' ]"
   with_items: "{{ consul_services }}"
@@ -55,7 +55,7 @@
   when: ansible_os_family != 'Windows'
 
 - name: Find all service config files that we manage [Windows]
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ consul_configd_path }}/service_{{ service_config_item.name }}.json"
   with_items: "{{ consul_services }}"
   loop_control:
@@ -64,7 +64,7 @@
   when: ansible_os_family == 'Windows'
 
 - name: Set fact with list of services we manage [Windows]
-  set_fact:
+  ansible.builtin.set_fact:
     managed_files: "{{ managed_files | default([]) }} + [ '{{ service_item.stat.path }}' ]"
   with_items: "{{ managed_files_win_paths.results }}"
   loop_control:
@@ -72,7 +72,7 @@
   when: ansible_os_family == 'Windows'
 
 - name: Delete non declared services
-  file:
+  ansible.builtin.file:
     path: "{{ non_declared_service_item }}"
     state: absent
   when:
@@ -87,7 +87,7 @@
     - restart consul
 
 - name: Delete non declared services [Windows]
-  win_file:
+  ansible.windows.win_file:
     path: "{{ non_declared_service_item }}"
     state: absent
   when:

--- a/tasks/snapshot.yml
+++ b/tasks/snapshot.yml
@@ -16,7 +16,7 @@
     dest: /lib/systemd/system/consul_snapshot.service
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   register: systemd_unit
   notify: start snapshot
   when:
@@ -31,7 +31,7 @@
     dest: "{{ consul_config_path }}/consul_snapshot.json"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    mode: 0644
+    mode: "0644"
   notify: start snapshot
   when:
     - ansible_service_mgr == "systemd"
@@ -40,9 +40,9 @@
     - consul_snapshot | bool
 
 - name: Reload systemd
-  ansible.builtin.systemd:
+  ansible.builtin.systemd_service:
     daemon_reload: true
-  when: systemd_unit | changed
+  when: systemd_unit is changed
 
 - name: Create snaps storage folder
   ansible.builtin.file:
@@ -50,4 +50,4 @@
     path: "{{ consul_snapshot_storage }}"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    mode: 0744
+    mode: "0744"

--- a/tasks/snapshot.yml
+++ b/tasks/snapshot.yml
@@ -11,7 +11,7 @@
 # update my vars file
 
 - name: Create snapshot systemd script
-  template:
+  ansible.builtin.template:
     src: consul_systemd_snapshot.service.j2
     dest: /lib/systemd/system/consul_snapshot.service
     owner: root
@@ -26,7 +26,7 @@
     - consul_snapshot | bool
 
 - name: Create snapshot agent config
-  template:
+  ansible.builtin.template:
     src: consul_snapshot.json.j2
     dest: "{{ consul_config_path }}/consul_snapshot.json"
     owner: "{{ consul_user }}"
@@ -40,12 +40,12 @@
     - consul_snapshot | bool
 
 - name: Reload systemd
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: true
   when: systemd_unit | changed
 
 - name: Create snaps storage folder
-  file:
+  ansible.builtin.file:
     state: directory
     path: "{{ consul_snapshot_storage }}"
     owner: "{{ consul_user }}"

--- a/tasks/syslog.yml
+++ b/tasks/syslog.yml
@@ -2,7 +2,7 @@
 # File: syslog.yml - syslog config for Consul logging
 
 - name: Detect syslog program
-  stat:
+  ansible.builtin.stat:
     path: /usr/sbin/syslog-ng
   register: stat_syslogng
   when:
@@ -10,7 +10,7 @@
     - consul_configure_syslogd | bool
 
 - name: Install syslog-ng config
-  template:
+  ansible.builtin.template:
     src: syslogng_consul.conf.j2
     dest: /etc/syslog-ng/conf.d/consul.conf
     owner: root
@@ -26,7 +26,7 @@
     - restart consul
 
 - name: Install rsyslogd config
-  template:
+  ansible.builtin.template:
     src: rsyslogd_00-consul.conf.j2
     dest: /etc/rsyslog.d/00-consul.conf
     owner: root

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -4,7 +4,7 @@
 - name: Copy CA certificate
   block:
     - name: Create SSL directory
-      file:
+      ansible.builtin.file:
         dest: "{{ consul_tls_dir }}"
         state: directory
         owner: "{{ consul_user }}"
@@ -12,7 +12,7 @@
         mode: 0755
 
     - name: Copy CA certificate
-      copy:
+      ansible.builtin.copy:
         remote_src: "{{ consul_tls_files_remote_src }}"
         src: "{{ consul_tls_ca_crt }}"
         dest: "{{ consul_tls_dir }}/{{ consul_tls_ca_crt | basename }}"
@@ -26,7 +26,7 @@
 - name: Copy server certificate and key
   block:
     - name: Copy server certificate
-      copy:
+      ansible.builtin.copy:
         remote_src: "{{ consul_tls_files_remote_src }}"
         src: "{{ consul_tls_server_crt }}"
         dest: "{{ consul_tls_dir }}/{{ consul_tls_server_crt | basename }}"
@@ -36,7 +36,7 @@
       notify: restart consul
 
     - name: Copy server key
-      copy:
+      ansible.builtin.copy:
         remote_src: "{{ consul_tls_files_remote_src }}"
         src: "{{ consul_tls_server_key }}"
         dest: "{{ consul_tls_dir }}/{{ consul_tls_server_key | basename }}"

--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -3,7 +3,7 @@
 
 # Add group
 - name: Add Consul group
-  group:
+  ansible.builtin.group:
     name: "{{ consul_group }}"
     state: present
   when:
@@ -12,7 +12,7 @@
 
 # Add user
 - name: Add Consul user
-  user:
+  ansible.builtin.user:
     name: "{{ consul_user }}"
     comment: "Consul user"
     group: "{{ consul_group }}"

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -26,7 +26,8 @@
   tags: always
 
 - name: (Windows) Include directory settings
-  ansible.builtin.import_tasks: dirs.yml
+  ansible.builtin.import_tasks:
+    file: dirs.yml
 
 - name: (Windows) Check for existing Consul binary
   ansible.windows.win_stat:
@@ -48,7 +49,8 @@
       consul_installed_version.stdout_lines[0] != _consul_expected_version_string }}"
 
 - name: (Windows) Install OS packages and consul
-  ansible.builtin.include_tasks: install_windows.yml
+  ansible.builtin.include_tasks:
+    file: install_windows.yml
   when: consul_install_binary | bool
 
 - name: (Windows) Write gossip encryption key
@@ -143,7 +145,8 @@
   when: consul_encrypt_enable
 
 - name: (Windows) Create Consul configuration
-  ansible.builtin.import_tasks: config_windows.yml
+  ansible.builtin.import_tasks:
+    file: config_windows.yml
 
 - name: (Windows) Ensure neither ACL nor TLS are requested
   ansible.builtin.fail:
@@ -151,11 +154,13 @@
   when: consul_acl_enable | bool
 
 - name: (Windows) Create ACL configuration
-  ansible.builtin.include_tasks: acl.yml
+  ansible.builtin.include_tasks:
+    file: acl.yml
   when: consul_acl_enable | bool
 
 - name: (Windows) Create TLS configuration
-  ansible.builtin.include_tasks: tls.yml
+  ansible.builtin.include_tasks:
+    file: tls.yml
   when: consul_tls_enable | bool
 
 - name: (Windows) Install consul and create service
@@ -198,7 +203,8 @@
       when: ansible_os_family == "Windows"
 
     - name: Configure iptables
-      ansible.builtin.include_tasks: ../tasks/iptables.yml
+      ansible.builtin.include_tasks:
+        file: ../tasks/iptables.yml
       when: consul_iptables_enable | bool
 
   when: not bootstrap_state.stat.exists
@@ -211,5 +217,6 @@
   when: bootstrap_state.stat.exists
 
 - name: Include tassk to configure dnsmasq
-  ansible.builtin.include_tasks: ../tasks/dnsmasq.yml
+  ansible.builtin.include_tasks:
+    file: ../tasks/dnsmasq.yml
   when: consul_dnsmasq_enable | bool

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -3,7 +3,7 @@
 # 'delegate_facts' is currently rather buggy in Ansible so this might not
 # always work. Hence 'consul_gather_server_facts' defaults to 'no'.
 - name: (Windows) Gather facts from other servers
-  setup:
+  ansible.builtin.setup:
   delegate_to: "{{ host_item }}"
   delegate_facts: true
   with_items: "{{ consul_servers | difference(play_hosts) }}"
@@ -13,28 +13,28 @@
   when: consul_gather_server_facts | bool
 
 - name: (Windows) Expose bind_address, datacenter and node_role as facts
-  set_fact:
+  ansible.builtin.set_fact:
     consul_bind_address: "{{ consul_bind_address }}"
     consul_datacenter: "{{ consul_datacenter }}"
     consul_node_role: "{{ consul_node_role }}"
 
 - name: (Windows) Read bootstrapped state
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ consul_bootstrap_state }}"
   register: bootstrap_state
   ignore_errors: true
   tags: always
 
 - name: (Windows) Include directory settings
-  import_tasks: dirs.yml
+  ansible.builtin.import_tasks: dirs.yml
 
 - name: (Windows) Check for existing Consul binary
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ consul_binary }}"
   register: consul_binary_installed
 
 - name: (Windows) Get current Consul version
-  win_command: "{{ consul_binary }} --version"
+  ansible.windows.win_command: "{{ consul_binary }} --version"
   changed_when: false
   when:
     - not consul_force_install
@@ -42,13 +42,13 @@
   register: consul_installed_version
 
 - name: (Windows) Calculate whether to install consul binary
-  set_fact:
+  ansible.builtin.set_fact:
     consul_install_binary: "{{ consul_force_install or \
       not consul_binary_installed.stat.exists or \
       consul_installed_version.stdout_lines[0] != _consul_expected_version_string }}"
 
 - name: (Windows) Install OS packages and consul
-  include_tasks: install_windows.yml
+  ansible.builtin.include_tasks: install_windows.yml
   when: consul_install_binary | bool
 
 - name: (Windows) Write gossip encryption key
@@ -56,18 +56,18 @@
     - name: (Windows) Save existing gossip encryption key
       block:
         - name: (Windows) Check for gossip encryption key on previously boostrapped server
-          slurp:
+          ansible.builtin.slurp:
             src: "{{ consul_config_path }}/config.json"
           register: consul_config_b64
           ignore_errors: true
 
         - name: (Windows) Deserialize existing configuration
-          set_fact:
+          ansible.builtin.set_fact:
             consul_config: "{{ consul_config_b64.content | b64decode | from_json }}"
           when: consul_config_b64.content is defined
 
         - name: (Windows) Save gossip encryption key from existing configuration
-          set_fact:
+          ansible.builtin.set_fact:
             consul_raw_key: "{{ consul_config.encrypt }}"
           when: consul_config is defined
 
@@ -79,7 +79,7 @@
 
     - name: Create temporary file for raw gossip encryption key
       delegate_to: localhost
-      tempfile:
+      ansible.builtin.tempfile:
         suffix: ".key"
       register: consul_raw_key_file
       become: false
@@ -89,7 +89,7 @@
 
     # Key provided by extra vars or the above block
     - name: (Windows) Write gossip encryption key locally for use with new servers
-      copy:
+      ansible.builtin.copy:
         content: "{{ consul_raw_key }}"
         dest: "{{ consul_raw_key_file.path }}"
         mode: 0600
@@ -105,12 +105,12 @@
       block:
 
         - name: (Windows) Generate gossip encryption key
-          win_shell: "{{ consul_binary }} keygen"
+          ansible.windows.win_shell: "{{ consul_binary }} keygen"
           no_log: true
           register: consul_keygen
 
         - name: (Windows) Write key locally to share with other nodes
-          copy:
+          ansible.builtin.copy:
             content: "{{ consul_keygen.stdout }}"
             dest: "{{ consul_raw_key_file.path }}"
             mode: 0600
@@ -125,13 +125,13 @@
         - not bootstrap_state.stat.exists | bool
 
     - name: (Windows) Read gossip encryption key for servers that require it
-      set_fact:
+      ansible.builtin.set_fact:
         consul_raw_key: "{{ lookup('file', consul_raw_key_file.path) }}"
       no_log: true
       when: consul_raw_key is not defined
 
     - name: (Windows) Delete gossip encryption key file
-      file:
+      ansible.builtin.file:
         path: "{{ consul_raw_key_file.path }}"
         state: absent
       become: false
@@ -143,35 +143,35 @@
   when: consul_encrypt_enable
 
 - name: (Windows) Create Consul configuration
-  import_tasks: config_windows.yml
+  ansible.builtin.import_tasks: config_windows.yml
 
 - name: (Windows) Ensure neither ACL nor TLS are requested
-  fail:
+  ansible.builtin.fail:
     msg: "ACL is not supported on Windows hosts yet."
   when: consul_acl_enable | bool
 
 - name: (Windows) Create ACL configuration
-  include_tasks: acl.yml
+  ansible.builtin.include_tasks: acl.yml
   when: consul_acl_enable | bool
 
 - name: (Windows) Create TLS configuration
-  include_tasks: tls.yml
+  ansible.builtin.include_tasks: tls.yml
   when: consul_tls_enable | bool
 
 - name: (Windows) Install consul and create service
   block:
     - name: Convert consul_binary from Unix -> Windows
-      win_stat:
+      ansible.windows.win_stat:
         path: "{{ consul_binary }}"
       register: consul_binary_win
 
     - name: Convert consul_config_path from Unix -> Windows
-      win_stat:
+      ansible.windows.win_stat:
         path: "{{ consul_config_path }}"
       register: consul_config_path_win
 
     - name: Convert consul_configd_path from Unix -> Windows
-      win_stat:
+      ansible.windows.win_stat:
         path: "{{ consul_configd_path }}"
       register: consul_configd_path_win
 
@@ -187,29 +187,29 @@
         state: started
 
     - name: (Windows) Check Consul HTTP API
-      win_wait_for:
+      ansible.windows.win_wait_for:
         delay: 5
         port: 8500
 
     - name: (Windows) Create bootstrapped state file
-      win_file:
+      ansible.windows.win_file:
         dest: "{{ consul_bootstrap_state }}"
         state: touch
       when: ansible_os_family == "Windows"
 
     - name: Configure iptables
-      include_tasks: ../tasks/iptables.yml
+      ansible.builtin.include_tasks: ../tasks/iptables.yml
       when: consul_iptables_enable | bool
 
   when: not bootstrap_state.stat.exists
 
 # The service is stopped before updating Consul
 - name: Ensure Consul service is started
-  win_service:
+  ansible.windows.win_service:
     name: Consul
     state: started
   when: bootstrap_state.stat.exists
 
 - name: Include tassk to configure dnsmasq
-  include_tasks: ../tasks/dnsmasq.yml
+  ansible.builtin.include_tasks: ../tasks/dnsmasq.yml
   when: consul_dnsmasq_enable | bool


### PR DESCRIPTION
This PR fixes some linting errors for the `ansible-consul` role, applied on Ansible version 2.14.

I've used this version since ansible-core 2.14 is still supported (https://endoflife.date/ansible-core) and ansible-core 2.8 is unsupported.

Most notable changes:

- switched `systemd` to `ansible.builtin.systemd_service` module (see: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/systemd_module.html and https://docs.ansible.com/ansible/latest/collections/ansible/builtin/systemd_service_module.html#ansible-collections-ansible-builtin-systemd-service-module)
- added `file` parameter for `ansible.builtin.import_tasks` (see: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/import_tasks_module.html#parameter-file)

I was not sure if `ansible.windows` can be removed as a requirement now, as it is replaced by `community.windows` in newer Ansible versions.

While testing locally with Molecule, I've encountered some errors like:

Command: `molecule --base-config molecule/_shared/base.yml converge --scenario-name debian-11`

Error:
```
Prepare stage:

TASK [Install OS packages] *****************************************************
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
So maybe someone can give me a little hint here.

Otherwise, I still hope that this PR will be reviewed and possibly successfully merged. Please write to me if there is anything missing in this PR!