### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Molecule
-        uses: gofrolist/molecule-action@v2.6.10
+        uses: gofrolist/molecule-action@v2.7.6
         with:
           molecule_options: --base-config molecule/_shared/base.yml
           molecule_args: --scenario-name ${{ matrix.scenario }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Molecule
         uses: gofrolist/molecule-action@v2.6.10

--- a/molecule/_shared/converge.yml
+++ b/molecule/_shared/converge.yml
@@ -7,5 +7,7 @@
   vars:
     # Force SysVinit, since systemd won't work in a Docker container
     ansible_service_mgr: sysvinit
+    # We install netaddr in the prepare.yml playbook
+    consul_install_dependencies: false
     # TODO: Probably we need to install syslog-ng/rsyslog first
     consul_syslog_enable: false


### PR DESCRIPTION
Attempting to install `netaddr` in `tasks/main.yml` resulted in an error:

```
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```

Fortunately, we already install `netaddr` in `prepare.yml` and can define `consul_install_dependencies: false`, since we don't require any other dependencies.

This PR also updates the `checkout` and `molecule` GitHub actions to their latest versions.