### PR TITLE
Update links to reflect new organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Consul
 
-![Molecule](https://github.com/ansible-community/ansible-consul/workflows/Molecule/badge.svg?branch=master&event=pull_request)
-[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/ansible-community/ansible-consul.svg)](http://isitmaintained.com/project/ansible-community/ansible-consul "Average time to resolve an issue")
-[![Percentage of issues still open](http://isitmaintained.com/badge/open/ansible-community/ansible-consul.svg)](http://isitmaintained.com/project/ansible-community/ansible-consul "Percentage of issues still open")
+![Molecule](https://github.com/ansible-collections/ansible-consul/workflows/Molecule/badge.svg?branch=master&event=pull_request)
+[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/ansible-collections/ansible-consul.svg)](http://isitmaintained.com/project/ansible-collections/ansible-consul "Average time to resolve an issue")
+[![Percentage of issues still open](http://isitmaintained.com/badge/open/ansible-collections/ansible-consul.svg)](http://isitmaintained.com/project/ansible-collections/ansible-consul "Percentage of issues still open")
 
 This Ansible role installs [Consul](https://consul.io/), including establishing a filesystem structure and server or client agent configuration with support for some common operational features.
 
-It can also bootstrap a development or evaluation cluster of 3 server agents running in a Vagrant and VirtualBox based environment. See [README_VAGRANT.md](https://github.com/ansible-community/ansible-consul/blob/master/examples/README_VAGRANT.md) and the associated [Vagrantfile](https://github.com/ansible-community/ansible-consul/blob/master/examples/Vagrantfile) for more details.
+It can also bootstrap a development or evaluation cluster of 3 server agents running in a Vagrant and VirtualBox based environment. See [README_VAGRANT.md](https://github.com/ansible-collections/ansible-consul/blob/master/examples/README_VAGRANT.md) and the associated [Vagrantfile](https://github.com/ansible-collections/ansible-consul/blob/master/examples/Vagrantfile) for more details.
 
 ## Role Philosophy
 
@@ -20,11 +20,11 @@ Many users have expressed that the Vagrant based environment makes getting a wor
 If you get some mileage from it in other ways, then all the better!
 
 ## Role migration and installation
-This role was originally developed by Brian Shumate and was known on Ansible Galaxy as **brianshumate.consul**. Brian asked the community to be relieved of the maintenance burden, and therefore Bas Meijer transferred the role to **ansible-community** so that a team of volunteers can maintain it. At the moment there is no membership of ansible-community on https://galaxy.ansible.com and therefore to install this role into your project you should create a file `requirements.yml` in the subdirectory `roles/` of your project with this content:
+This role was originally developed by Brian Shumate and was known on Ansible Galaxy as **brianshumate.consul**. Brian asked the community to be relieved of the maintenance burden, and therefore Bas Meijer transferred the role to **ansible-collections** so that a team of volunteers can maintain it. To install this role into your project you should create a file `requirements.yml` in the subdirectory `roles/` of your project with this content:
 
 ```
 ---
-- src: https://github.com/ansible-community/ansible-consul.git
+- src: https://github.com/ansible-collections/ansible-consul.git
   name: ansible-consul
   scm: git
   version: master
@@ -1279,7 +1279,7 @@ redis
 
 ### Vagrant and VirtualBox
 
-See [examples/README_VAGRANT.md](https://github.com/ansible-community/ansible-consul/blob/master/examples/README_VAGRANT.md) for details on quick Vagrant deployments under VirtualBox for development, evaluation, testing, etc.
+See [examples/README_VAGRANT.md](https://github.com/ansible-collections/ansible-consul/blob/master/examples/README_VAGRANT.md) for details on quick Vagrant deployments under VirtualBox for development, evaluation, testing, etc.
 
 ## License
 
@@ -1291,6 +1291,6 @@ BSD
 
 ## Contributors
 
-Special thanks to the folks listed in [CONTRIBUTORS.md](https://github.com/ansible-community/ansible-consul/blob/master/CONTRIBUTORS.md) for their contributions to this project.
+Special thanks to the folks listed in [CONTRIBUTORS.md](https://github.com/ansible-collections/ansible-consul/blob/master/CONTRIBUTORS.md) for their contributions to this project.
 
-Contributions are welcome, provided that you can agree to the terms outlined in [CONTRIBUTING.md](https://github.com/ansible-community/ansible-consul/blob/master/CONTRIBUTING.md).
+Contributions are welcome, provided that you can agree to the terms outlined in [CONTRIBUTING.md](https://github.com/ansible-collections/ansible-consul/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
##### SUMMARY

On [12 Feb 2024](https://github.com/ansible-collections/ansible-inclusion/discussions/64#discussioncomment-8438016), this role was transferred to the `ansible-collections` organization. A larger refactoring will take place in the future, but for now, let's at least update the URLs to point to the new home.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
Documentation

##### ADDITIONAL INFORMATION
N/A