### PR TITLE
introduced consul_systemd_service_name variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,7 @@ consul_systemd_restart: on-failure
 consul_systemd_restart_sec: 42
 consul_systemd_limit_nofile: 65536
 consul_systemd_unit_path: /lib/systemd/system
+consul_systemd_service_name: consul
 
 ### Log user, group, facility
 syslog_user: "{{ lookup('env', 'SYSLOG_USER') | default('root', true) }}"

--- a/handlers/restart_consul.yml
+++ b/handlers/restart_consul.yml
@@ -8,7 +8,7 @@
 
 - name: Restart consul on Unix
   ansible.builtin.service:
-    name: consul
+    name: "{{ consul_systemd_service_name }}"
     state: restarted
     # Needed to force SysV service manager on Docker for Molecule tests
     use: "{{ ansible_service_mgr }}"
@@ -38,7 +38,7 @@
 
 - name: Restart consul on Windows
   ansible.windows.win_service:
-    name: consul
+    name: "{{ consul_systemd_service_name }}"
     state: restarted
   # Some tasks with `become: true` end up calling this task. Unfortunately, the `become`
   # property is evaluated before the `when` condition and this results in an Ansible

--- a/handlers/start_consul.yml
+++ b/handlers/start_consul.yml
@@ -1,7 +1,7 @@
 ---
 - name: Start consul on Unix
   ansible.builtin.service:
-    name: consul
+    name: "{{ consul_systemd_service_name }}"
     state: started
     # Needed to force SysV service manager on Docker for Molecule tests
     use: "{{ ansible_service_mgr }}"
@@ -17,7 +17,7 @@
 
 - name: Start consul on Windows
   ansible.windows.win_service:
-    name: consul
+    name: "{{ consul_systemd_service_name }}"
     state: started
   when: ansible_os_family == "Windows"
   listen: start consul

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -22,7 +22,7 @@
 
     - name: Stop service consul, if running
       ansible.builtin.service:
-        name: consul
+        name: "{{ consul_systemd_service_name }}"
         state: stopped
         # Needed to force SysV service manager on Docker for Molecule tests
         use: "{{ ansible_service_mgr }}"
@@ -80,9 +80,9 @@
     state: present
   become: true
 
-- name: Create a directory /etc/systemd/system/consul.service.d
+- name: "Create a directory /etc/systemd/system/{{ consul_systemd_service_name }}.service.d"
   ansible.builtin.file:
-    path: /etc/systemd/system/consul.service.d
+    path: "/etc/systemd/system/{{ consul_systemd_service_name }}.service.d"
     state: directory
     mode: "0755"
     owner: root
@@ -94,7 +94,7 @@
 - name: Override systemd service params
   ansible.builtin.template:
     src: consul_systemd_service.override.j2
-    dest: /etc/systemd/system/consul.service.d/override.conf
+    dest: "/etc/systemd/system/{{ consul_systemd_service_name }}.service.d/override.conf"
     owner: root
     group: root
     mode: "0644"

--- a/tasks/leave_restart_consul.yml
+++ b/tasks/leave_restart_consul.yml
@@ -8,7 +8,7 @@
 - name: Restart consul on Unix
   delegate_to: "{{ rolling_restart_host }}"
   ansible.builtin.service:
-    name: consul
+    name: "{{ consul_systemd_service_name }}"
     state: restarted
     # Needed to force SysV service manager on Docker for Molecule tests
     use: "{{ ansible_service_mgr }}"

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -234,7 +234,7 @@
 - name: Create systemd script
   ansible.builtin.template:
     src: consul_systemd.service.j2
-    dest: "{{ consul_systemd_unit_path }}/consul.service"
+    dest: "{{ consul_systemd_unit_path }}/{{ consul_systemd_service_name }}.service"
     owner: root
     group: root
     mode: "0644"
@@ -254,7 +254,7 @@
 
 - name: Enable consul at startup (systemd)
   ansible.builtin.systemd_service:
-    name: consul
+    name: "{{ consul_systemd_service_name }}"
     enabled: true
   when:
     - ansible_service_mgr == "systemd"
@@ -312,7 +312,7 @@
   block:
     - name: Start Consul
       ansible.builtin.service:
-        name: consul
+        name: "{{ consul_systemd_service_name }}"
         state: started
         enabled: true
         # Needed to force SysV service manager on Docker for Molecule tests

--- a/templates/consul_systemd_snapshot.service.j2
+++ b/templates/consul_systemd_snapshot.service.j2
@@ -11,7 +11,7 @@
 [Unit]
 Description=Consul snapshot agent
 Requires=network-online.target
-Requisite=consul.service
+Requisite={{ consul_systemd_service_name }}.service
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
##### SUMMARY
introduced consul_systemd_service_name variable to allow specifying name of service (and related directories), solving the issue of running multiple instances on the same machine

##### ISSUE TYPE
- Feature Pull Request

