### PR TITLE
Fix ubuntu 22.04 molecule test to actually run on 22.04

### DIFF
--- a/molecule/_shared/Dockerfile.j2
+++ b/molecule/_shared/Dockerfile.j2
@@ -18,7 +18,7 @@ RUN if [ $(command -v apt-get) ]; then \
         if grep -q "Debian GNU/Linux 11" /etc/os-release; then \
             apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 python-apt-common && apt-get clean; \
         else \
-            apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python-apt && apt-get clean; \
+            apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt && apt-get clean; \
         fi \
     elif [ $(command -v dnf) ]; then \
         dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 sudo bash iproute && dnf clean all; \

--- a/molecule/_shared/Dockerfile.j2
+++ b/molecule/_shared/Dockerfile.j2
@@ -18,7 +18,7 @@ RUN if [ $(command -v apt-get) ]; then \
         if grep -q "Debian GNU/Linux 11" /etc/os-release; then \
             apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 python-apt-common && apt-get clean; \
         else \
-            apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 python-apt && apt-get clean; \
+            apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python-apt && apt-get clean; \
         fi \
     elif [ $(command -v dnf) ]; then \
         dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 sudo bash iproute && dnf clean all; \

--- a/molecule/ubuntu-22.04/molecule.yml
+++ b/molecule/ubuntu-22.04/molecule.yml
@@ -3,7 +3,7 @@ platforms:
   - name: ubuntu-22.04
     groups:
       - consul_instances
-    image: dokken/ubuntu-20.04
+    image: dokken/ubuntu-22.04
     command: /lib/systemd/systemd
     dockerfile: ../_shared/Dockerfile.j2
     capabilities:


### PR DESCRIPTION
##### SUMMARY

`molecule/ubuntu-22.04/molecule.yml` used 20.04 instead of 22.04, this definitely was not intended.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
