### PR TITLE
fix grpc_tls port value in config.json.j2

### DIFF
--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -35,7 +35,7 @@
         "grpc": "{{ consul_addresses.grpc }}",
         {% endif %}
         {% if consul_version is version_compare('1.14.0', '>=') %}
-        "grpc_tls": "{{ consul_addresses.grpc_tls }}",
+        "grpc_tls": "{{ consul_ports.grpc_tls }}",
         {% endif %}
     },
     {## Ports Used ##}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix grpc_tls port value in config.json.j2
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
task
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Task failed with error 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
{"changed": false, "cmd": ["/usr/local/bin/consul", "validate", "-quiet", "/etc/consul/config.json", "/etc/consul.d"], "delta": "0:00:00.120234", "end": "2024-10-10 07:57:18.225071", "msg": "non-zero return code", "rc": 1, "start": "2024-10-10 07:57:18.104837", "stderr": "Config validation failed: failed to parse /etc/consul/config.json: 1 error(s) decoding:\n\n* 'ports.grpc_tls' expected type 'int', got unconvertible type 'string', value: '127.0.0.1'", "stderr_lines": ["Config validation failed: failed to parse /etc/consul/config.json: 1 error(s) decoding:", "", "* 'ports.grpc_tls' expected type 'int', got unconvertible type 'string', value: '127.0.0.1'"], "stdout": "", "stdout_lines": []}
```
