### PR TITLE
Adding consul_log_json config option and updating version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,6 +65,7 @@ consul_systemd_unit_path: /lib/systemd/system
 ### Log user, group, facility
 syslog_user: "{{ lookup('env', 'SYSLOG_USER') | default('root', true) }}"
 syslog_group: "{{ lookup('env', 'SYSLOG_GROUP') | default('adm', true) }}"
+consul_log_json: "{{ lookup('env', 'CONSUL_LOG_JSON') | default(false, false) }}"
 consul_log_level: "{{ lookup('env', 'CONSUL_LOG_LEVEL') | default('INFO', true) }}"
 consul_log_rotate_bytes: "{{ lookup('env', 'CONSUL_LOG_ROTATE_BYTES') | default(0, true) }}"
 consul_log_rotate_duration: "{{ lookup('env', 'CONSUL_LOG_ROTATE_DURATION') | default('24h', true) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ virtualenv: "{{ lookup('env', 'VIRTUAL_ENV') | default('') }}"
 consul_install_dependencies: true
 
 ### Package
-consul_version: "{{ lookup('env', 'CONSUL_VERSION') | default('1.8.7', true) }}"
+consul_version: "{{ lookup('env', 'CONSUL_VERSION') | default('1.20.0', true) }}"
 consul_architecture_map:
   # this first entry seems redundant
   # (but it's required for reasons)

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -67,6 +67,7 @@
 
     {## Agent ##}
     "data_dir": "{{ consul_data_path }}",
+    "log_json": "{{ consul_log_json }}",
     "log_level": "{{ consul_log_level }}",
     {% if consul_syslog_enable | bool %}
     "enable_syslog": {{ consul_syslog_enable | bool | to_json }},


### PR DESCRIPTION
Current version doesn't provide a way to configure an `log_json` agent's option. I think it's nice to add it.
