### PR TITLE
set log directory permission to 0750

### DIFF
--- a/tasks/dirs.yml
+++ b/tasks/dirs.yml
@@ -32,7 +32,7 @@
     state: directory
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    mode: "0700"
+    mode: "0750"
   when:
     - ansible_os_family != 'Windows'
     - not consul_syslog_enable | bool
@@ -44,7 +44,7 @@
     state: directory
     owner: "{{ syslog_user }}"
     group: "{{ syslog_group }}"
-    mode: "0700"
+    mode: "0750"
   with_items:
     - "{{ consul_log_path }}"
   loop_control:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I am using `td-agent` to collect logs from consul. The current default permission prevented `td-agent`'s user to list the log directory and read the log file. This MR will set log directory permission to `0750` instead of `0700`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
