### PR TITLE
Avoid jinja2 templating delimiters usage in when condition

### DIFF
--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -36,11 +36,11 @@
     mode: "0644"
   become: true
   notify: restart dnsmasq
-  when: "{{ dnsmasq_item.when }}"
+  when: dnsmasq_item.when
   tags: dnsmasq
   loop:
-    - { dest: /etc/dnsmasq.d/10-consul, group: root, when: ansible_os_family|lower != "freebsd" }
-    - { dest: /usr/local/etc/dnsmasq.d/consul.conf, group: wheel, when: ansible_os_family|lower == "freebsd" }
+    - { dest: /etc/dnsmasq.d/10-consul, group: root, when: '{{ ansible_os_family|lower != "freebsd" }}' }
+    - { dest: /usr/local/etc/dnsmasq.d/consul.conf, group: wheel, when: '{{ ansible_os_family|lower == "freebsd" }}' }
   loop_control:
     loop_var: dnsmasq_item
 


### PR DESCRIPTION
##### SUMMARY

Avoid warning about using jinja2 templating delimiters in when condition.
 
```
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ dnsmasq_item.when }}

```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-consul collection