### PR TITLE
Fix ansible 12

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,7 +85,7 @@ consul_iface: "\
     {{ lookup('env', 'CONSUL_IFACE') | default(ansible_default_ipv4.interface, true) }}\
   {% endif %}"
 consul_node_role: "{{ lookup('env', 'CONSUL_NODE_ROLE') | default('client', true) }}"
-consul_recursors: "{{ lookup('env', 'CONSUL_RECURSORS') | default('[]', true) }}"
+consul_recursors: "{{ lookup('env', 'CONSUL_RECURSORS') | default('[]', true) | from_yaml }}"
 consul_bootstrap_expect: "{{ lookup('env', 'CONSUL_BOOTSTRAP_EXPECT') | default(false, true) }}"
 consul_bootstrap_expect_value: "{{ _consul_lan_servercount | int }}"
 consul_ui: "{{ lookup('env', 'CONSUL_UI') | default(true, true) }}"

--- a/tasks/nix.yml
+++ b/tasks/nix.yml
@@ -324,7 +324,7 @@
         delay: 15
         port: "{{ consul_ports.http | int }}"
         host: "{{ consul_addresses.http }}"
-      when: (consul_ports.http | int > -1) and (consul_addresses.http | ansible.utils.ipaddr)
+      when: (consul_ports.http | int > -1) and (consul_addresses.http | ansible.utils.ipaddr) is truthy
 
     - name: Check Consul HTTP API (via unix socket)
       ansible.builtin.wait_for:


### PR DESCRIPTION
### SUMMARY

When running the role with ansible 12, it fails for multiple reasons:
- Conditional result (True) was derived from value of type 'str'
- consul_recursors fails validation as an arrqay is expected instead of a string `"[]"`

###  ISSUE TYPE

    Bugfix Pull Request

### COMPONENT NAME

Task

### ADDITIONAL INFORMATION

The fix :
- ensure condition to be a boolean
- consul_recursors convert to enforce to be an array
